### PR TITLE
Updated readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,13 @@ featuring
 .. _write callback design mistake:
                   http://www.python.org/dev/peps/pep-0333/#the-write-callable
 
+Why It's Not Cool
+~~~~~~~~~~~~~~~~~
+
+* Entirely written as a C extension, so portability may be a concern.
+* Not HTTP/1.1 capable (yet).
+
+
 Installation
 ~~~~~~~~~~~~
 libev


### PR DESCRIPTION
Now includes a "Why It's Not Cool" section with two points, mentioning portability (as code which compiles against CPython) and HTTP/1.1 (possible to-do item).  Meant to be humorous and in the style of the "Why it's cool" section.  (Neither point is particularly severe. ;)
