### PR TITLE
Add clarification for abstract sockets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,9 @@ Usage
    # Bind to Unix socket:
    bjoern.run(wsgi_application, 'unix:/path/to/socket')
 
+   # Bind to abstract Unix socket: (Linux only)
+   bjoern.run(wsgi_application, 'unix:@socket_name')
+
 Alternatively, the mainloop can be run separately::
 
    bjoern.listen(wsgi_application, host, port)

--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -89,7 +89,7 @@ bool server_init(const char* hostaddr, const int port)
     sockaddr.sun_family = PF_UNIX;
     strcpy(sockaddr.sun_path, hostaddr);
 
-    /* Use @ for abstract */
+    /* Use @ for abstract (Linux) */
     if(hostaddr[0] == '@')
       sockaddr.sun_path[0] = '\0';
     else


### PR DESCRIPTION
I was confused for a bit trying to test abstract sockets on osx - adding a note to the readme and server.c for clarification.
