### PR TITLE
Add #import <string.h> for files using memset

### DIFF
--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -1,5 +1,6 @@
 #include <Python.h>
 #include <cStringIO.h>
+#include <string.h>
 #include "request.h"
 #include "filewrapper.h"
 

--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>


### PR DESCRIPTION
This isn't strictly necessary since they import common.h which imports string.h, but it seems like the right thing to do.
