### PR TITLE
Enable receive steering on FreeBSD and Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,9 @@ Usage
    # Bind to TCP host/port pair:
    bjoern.run(wsgi_application, host, port)
 
+   # TCP host/port pair, enabling SO_REUSEPORT if available.
+   bjoern.run(wsgi_application, host, port, reuseport=True)
+
    # Bind to Unix socket:
    bjoern.run(wsgi_application, 'unix:/path/to/socket')
 

--- a/bjoern/server.h
+++ b/bjoern/server.h
@@ -1,4 +1,4 @@
 #include "request.h"
 
-bool server_init(const char* hostaddr, const int port);
+bool server_init(const char* hostaddr, const int port, const int reuseport);
 void server_run(void);


### PR DESCRIPTION
Allows multiple independent bjoerns to bind to the same port (and
ideally also set their CPU affinity), resulting in much more efficient
load distribution.

Read more at https://lwn.net/Articles/542629/
