### PR TITLE
Fixes issue with high cpu usage with keep-alive and connection close

### DIFF
--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -131,10 +131,10 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
         DBG_REQ(request, "Client disconnected");
       else
         DBG_REQ(request, "Hit errno %d while read()ing", errno);
-      close(request->client_fd);
-      ev_io_stop(mainloop, &request->ev_watcher);
-      Request_free(request);
     }
+    close(request->client_fd);
+    ev_io_stop(mainloop, &request->ev_watcher);
+    Request_free(request);
     goto out;
   }
 


### PR DESCRIPTION
There is an issue where when a keep-alive request is received and the socket is closed, the poller does not stop reading from the fd, resulting in high cpu usage due to the spare reads. This pr fixes that.