### PR TITLE
sort input files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import glob
 from setuptools import setup, Extension
 
 SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c')] + \
-               glob.glob(os.path.join('bjoern', '*.c'))
+               sorted(glob.glob(os.path.join('bjoern', '*.c')))
 
 bjoern_extension = Extension(
     '_bjoern',


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the _bjoern.so output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.