### PR TITLE
Fix build on DragonFly

### DIFF
--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -2,7 +2,7 @@
 #include <fcntl.h>
 #include <ev.h>
 
-#if defined __FreeBSD__
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 # include <netinet/in.h> /* for struct sockaddr_in */
 # include <sys/types.h>
 # include <sys/socket.h>


### PR DESCRIPTION
Without this change, compilation fails in server.c:

bjoern/server.c: In function 'ev_io_on_request':
bjoern/server.c:113:22: error: storage size of 'sockaddr' isn't known
  struct sockaddr_in sockaddr;
bjoern/server.c:116:20: error: invalid application of 'sizeof' to incomplete type 'struct sockaddr_in'
   addrlen = sizeof(struct sockaddr_in);