### PR TITLE
bjoern Python3 Port (tests/hello.py working)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
+*.swp
 *~
 build/
 dist/
 MANIFEST
+bjoern.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 SOURCE_DIR	= bjoern
 BUILD_DIR	= build
+PYTHON	?= python2
 
-PYTHON_INCLUDE	= $(shell python2-config --include)
-PYTHON_LDFLAGS	= $(shell python2-config --ldflags)
+PYTHON_INCLUDE	= $(shell ${PYTHON}-config --include)
+PYTHON_LDFLAGS	= $(shell ${PYTHON}-config --ldflags)
 
 HTTP_PARSER_DIR	= http-parser
 HTTP_PARSER_OBJ = $(HTTP_PARSER_DIR)/http_parser.o
@@ -13,7 +14,7 @@ objects		= $(HTTP_PARSER_OBJ) \
 		             $(wildcard $(SOURCE_DIR)/*.c))
 
 CPPFLAGS	+= $(PYTHON_INCLUDE) -I . -I $(SOURCE_DIR) -I $(HTTP_PARSER_DIR)
-CFLAGS		+= $(FEATURES) -std=c11 -fno-strict-aliasing -fcommon -fPIC -Wall
+CFLAGS		+= $(FEATURES) -std=c99 -fno-strict-aliasing -fcommon -fPIC -Wall
 LDFLAGS		+= $(PYTHON_LDFLAGS) -l ev -shared -fcommon
 
 ifneq ($(WANT_SENDFILE), no)
@@ -40,7 +41,7 @@ small: clean
 
 _bjoernmodule:
 	@$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(objects) -o $(BUILD_DIR)/_bjoern.so
-	@PYTHONPATH=$$PYTHONPATH:$(BUILD_DIR) python -c "import bjoern"
+	@PYTHONPATH=$$PYTHONPATH:$(BUILD_DIR) ${PYTHON} -c "import bjoern"
 
 again: clean all
 
@@ -81,19 +82,19 @@ wget:
 	wget -O - -q -S $(TEST_URL)
 
 valgrind:
-	valgrind --leak-check=full --show-reachable=yes python2 tests/empty.py
+	valgrind --leak-check=full --show-reachable=yes ${PYTHON} tests/empty.py
 
 callgrind:
-	valgrind --tool=callgrind python2 tests/wsgitest-round-robin.py
+	valgrind --tool=callgrind ${PYTHON} tests/wsgitest-round-robin.py
 
 memwatch:
 	watch -n 0.5 \
-	  'cat /proc/$$(pgrep -n python2)/cmdline | tr "\0" " " | head -c -1; \
+	  'cat /proc/$$(pgrep -n ${PYTHON})/cmdline | tr "\0" " " | head -c -1; \
 	   echo; echo; \
-	   tail -n +25 /proc/$$(pgrep -n python2)/smaps'
+	   tail -n +25 /proc/$$(pgrep -n ${PYTHON})/smaps'
 
 upload:
-	python2 setup.py sdist upload
+	${PYTHON} setup.py sdist upload
 
 $(HTTP_PARSER_OBJ):
 	$(MAKE) -C $(HTTP_PARSER_DIR) http_parser.o CFLAGS_DEBUG_EXTRA=-fPIC CFLAGS_FAST_EXTRA=-fPIC

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ objects		= $(HTTP_PARSER_OBJ) \
 		             $(wildcard $(SOURCE_DIR)/*.c))
 
 CPPFLAGS	+= $(PYTHON_INCLUDE) -I . -I $(SOURCE_DIR) -I $(HTTP_PARSER_DIR)
-CFLAGS		+= $(FEATURES) -std=c99 -fno-strict-aliasing -fcommon -fPIC -Wall
+CFLAGS		+= $(FEATURES) -std=c11 -fno-strict-aliasing -fcommon -fPIC -Wall
 LDFLAGS		+= $(PYTHON_LDFLAGS) -l ev -shared -fcommon
 
 ifneq ($(WANT_SENDFILE), no)
@@ -40,7 +40,7 @@ small: clean
 
 _bjoernmodule:
 	@$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(objects) -o $(BUILD_DIR)/_bjoern.so
-	@PYTHONPATH=$$PYTHONPATH:$(BUILD_DIR) python2 -c "import bjoern"
+	@PYTHONPATH=$$PYTHONPATH:$(BUILD_DIR) python3 -c "import bjoern"
 
 again: clean all
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ small: clean
 
 _bjoernmodule:
 	@$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(objects) -o $(BUILD_DIR)/_bjoern.so
-	@PYTHONPATH=$$PYTHONPATH:$(BUILD_DIR) python3 -c "import bjoern"
+	@PYTHONPATH=$$PYTHONPATH:$(BUILD_DIR) python -c "import bjoern"
 
 again: clean all
 

--- a/bjoern/25compat.h
+++ b/bjoern/25compat.h
@@ -2,4 +2,7 @@
 #define NOP do{}while(0)
 #define PyFile_IncUseCount(file) NOP
 #define PyFile_DecUseCount(file) NOP
+#if PY_MAJOR_VERSION >= 3
+#else
 #define PyVarObject_HEAD_INIT(type, size) PyObject_HEAD_INIT(type) size,
+#endif

--- a/bjoern/25compat.h
+++ b/bjoern/25compat.h
@@ -1,8 +1,0 @@
-#define Py_TYPE(ob) (((PyObject*)(ob))->ob_type)
-#define NOP do{}while(0)
-#define PyFile_IncUseCount(file) NOP
-#define PyFile_DecUseCount(file) NOP
-#if PY_MAJOR_VERSION >= 3
-#else
-#define PyVarObject_HEAD_INIT(type, size) PyObject_HEAD_INIT(type) size,
-#endif

--- a/bjoern/_bjoernmodule.c
+++ b/bjoern/_bjoernmodule.c
@@ -80,8 +80,6 @@ PyMODINIT_FUNC INIT_BJOERN(void)
   }
 
   PyModule_AddObject(bjoern_module, "version", Py_BuildValue("(iii)", 1, 4, 3));
-  PyModule_AddObject(bjoern_module, "FileWrapper", (PyObject *)&FileWrapper_Type);
-  PyModule_AddObject(bjoern_module, "StartResponse", (PyObject *)&StartResponse_Type);
   return bjoern_module;
 #else
   PyObject* bjoern_module = Py_InitModule("_bjoern", Bjoern_FunctionTable);

--- a/bjoern/common.c
+++ b/bjoern/common.c
@@ -51,4 +51,5 @@ void _init_common()
   _HTTP_1_0 = _Unicode_FromString("HTTP/1.0");
   _wsgi_input = _Unicode_FromString("wsgi.input");
   _empty_string = _Unicode_FromString("");
+  _empty_bytes = _Bytes_FromString("");
 }

--- a/bjoern/common.c
+++ b/bjoern/common.c
@@ -45,6 +45,11 @@ void _init_common()
   _(CONTENT_LENGTH);
   _(HTTP_CONTENT_TYPE);
   _(CONTENT_TYPE);
+
+  _(BytesIO);
+  _(write);
+  _(read);
+  _(seek);
 #undef _
 
   _HTTP_1_1 = _Unicode_FromString("HTTP/1.1");

--- a/bjoern/common.c
+++ b/bjoern/common.c
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "py2py3.h"
 
 #define UNHEX(c) ((c >= '0' && c <= '9') ? (c - '0') : \
                   (c >= 'a' && c <= 'f') ? (c - 'a' + 10) : \
@@ -28,7 +29,8 @@ size_t unquote_url_inplace(char* url, size_t len)
 
 void _init_common()
 {
-#define _(name) _##name = PyString_FromString(#name)
+
+#define _(name) _##name = _Unicode_FromString(#name)
   _(REMOTE_ADDR);
   _(PATH_INFO);
   _(QUERY_STRING);
@@ -45,8 +47,8 @@ void _init_common()
   _(CONTENT_TYPE);
 #undef _
 
-  _HTTP_1_1 = PyString_FromString("HTTP/1.1");
-  _HTTP_1_0 = PyString_FromString("HTTP/1.0");
-  _wsgi_input = PyString_FromString("wsgi.input");
-  _empty_string = PyString_FromString("");
+  _HTTP_1_1 = _Unicode_FromString("HTTP/1.1");
+  _HTTP_1_0 = _Unicode_FromString("HTTP/1.0");
+  _wsgi_input = _Unicode_FromString("wsgi.input");
+  _empty_string = _Unicode_FromString("");
 }

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -22,7 +22,8 @@ void _init_common(void);
 PyObject *_REMOTE_ADDR, *_PATH_INFO, *_QUERY_STRING, *_REQUEST_METHOD, *_GET,
          *_HTTP_CONTENT_LENGTH, *_CONTENT_LENGTH, *_HTTP_CONTENT_TYPE,
          *_CONTENT_TYPE, *_SERVER_PROTOCOL, *_SERVER_NAME, *_SERVER_PORT,
-         *_HTTP_1_1, *_HTTP_1_0, *_wsgi_input, *_close, *_empty_string;
+         *_HTTP_1_1, *_HTTP_1_0, *_wsgi_input, *_close, *_empty_string,
+	 *_empty_bytes;
 
 #ifdef DEBUG
   #define DBG_REQ(request, ...) \

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -1,8 +1,6 @@
 #ifndef __common_h__
 #define __common_h__
 
-#define DEBUG 1
-
 #include <Python.h>
 #include <stdlib.h>
 #include <stddef.h>

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -7,10 +7,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-#if PY_MINOR_VERSION < 6
-# include "25compat.h"
-#endif
-
 #define TYPE_ERROR_INNER(what, expected, ...) \
   PyErr_Format(PyExc_TypeError, what " must be " expected " " __VA_ARGS__)
 #define TYPE_ERROR(what, expected, got) \

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -23,7 +23,7 @@ PyObject *_REMOTE_ADDR, *_PATH_INFO, *_QUERY_STRING, *_REQUEST_METHOD, *_GET,
          *_HTTP_CONTENT_LENGTH, *_CONTENT_LENGTH, *_HTTP_CONTENT_TYPE,
          *_CONTENT_TYPE, *_SERVER_PROTOCOL, *_SERVER_NAME, *_SERVER_PORT,
          *_HTTP_1_1, *_HTTP_1_0, *_wsgi_input, *_close, *_empty_string,
-	 *_empty_bytes;
+	 *_empty_bytes, *_BytesIO, *_write, *_read, *_seek;
 
 #ifdef DEBUG
   #define DBG_REQ(request, ...) \

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -1,6 +1,8 @@
 #ifndef __common_h__
 #define __common_h__
 
+#define DEBUG 1
+
 #include <Python.h>
 #include <stdlib.h>
 #include <stddef.h>

--- a/bjoern/filewrapper.c
+++ b/bjoern/filewrapper.c
@@ -1,4 +1,5 @@
 #include "filewrapper.h"
+#include "py2py3.h"
 
 static PyObject*
 FileWrapper_New(PyTypeObject* cls, PyObject* args, PyObject* kwargs)
@@ -9,7 +10,7 @@ FileWrapper_New(PyTypeObject* cls, PyObject* args, PyObject* kwargs)
   if(!PyArg_ParseTuple(args, "O|I:FileWrapper", &file, &ignored_blocksize))
     return NULL;
 
-  if(!PyFile_Check(file)) {
+  if(!_File_Check(file)) {
     TYPE_ERROR("FileWrapper argument", "file", file);
     return NULL;
   }

--- a/bjoern/py2py3.h
+++ b/bjoern/py2py3.h
@@ -12,10 +12,13 @@
 #define _Unicode_GET_SIZE(obj) PyUnicode_GET_LENGTH(obj)
 #define _Bytes_Check(obj) PyBytes_Check(obj)
 #define _Unicode_Check(obj) PyUnicode_Check(obj)
-#define _Bytes_Resize(obj, len) _PyBytes_Resize(obj, len);
-#define _Unicode_Resize(obj, len) PyUnicode_Resize(obj, len);
+#define _Bytes_Resize(obj, len) _PyBytes_Resize(obj, len)
+#define _Unicode_Resize(obj, len) PyUnicode_Resize(obj, len)
 #define _FromLong(n) PyLong_FromLong(n)
-#define _File_Check(file) 1 /* To Be Fixed */
+#define _Callable_Check(obj)
+#define _fileno_name "fileno"
+#define _File_Check(file) (PyObject_HasAttrString(file, _fileno_name) && \
+		PyCallable_Check(PyObject_GetAttrString(file, _fileno_name)))
 #else
 #define _Bytes_AS_DATA(obj) PyString_AS_STRING(obj)
 #define _Unicode_AS_DATA(obj) PyString_AS_STRING(obj)
@@ -30,7 +33,7 @@
 #define _Bytes_Resize(obj, len) _PyString_Resize(obj, len)
 #define _Unicode_Resize(obj, len) _PyString_Resize(obj, len)
 #define _FromLong(n) PyInt_FromLong(n)
-#define _File_Check(file) PyFile_Check(file)
+#define _File_Check(file, temp_obj) PyFile_Check(file)
 #endif
 
 #endif /* _PY2PY3_H */

--- a/bjoern/py2py3.h
+++ b/bjoern/py2py3.h
@@ -18,7 +18,6 @@
 #define _Bytes_Resize(obj, len) _PyBytes_Resize(obj, len)
 #define _Unicode_Resize(obj, len) PyUnicode_Resize(obj, len)
 #define _FromLong(n) PyLong_FromLong(n)
-#define _Callable_Check(obj)
 #define _File_Check(file) (PyObject_HasAttrString(file, "fileno") && \
 		PyCallable_Check(PyObject_GetAttrString(file, "fileno")))
 #else

--- a/bjoern/py2py3.h
+++ b/bjoern/py2py3.h
@@ -2,6 +2,9 @@
 #define _PY2PY3_H
 
 #if PY_MAJOR_VERSION >= 3
+#define NOP do{}while(0)
+#define PyFile_IncUseCount(file) NOP
+#define PyFile_DecUseCount(file) NOP
 #define _Bytes_AS_DATA(obj) PyBytes_AS_STRING(obj)
 #define _Unicode_AS_DATA(obj) PyUnicode_AsUTF8(obj)
 #define _Bytes_FromString(name) PyBytes_FromString(name)
@@ -16,9 +19,8 @@
 #define _Unicode_Resize(obj, len) PyUnicode_Resize(obj, len)
 #define _FromLong(n) PyLong_FromLong(n)
 #define _Callable_Check(obj)
-#define _fileno_name "fileno"
-#define _File_Check(file) (PyObject_HasAttrString(file, _fileno_name) && \
-		PyCallable_Check(PyObject_GetAttrString(file, _fileno_name)))
+#define _File_Check(file) (PyObject_HasAttrString(file, "fileno") && \
+		PyCallable_Check(PyObject_GetAttrString(file, "fileno")))
 #else
 #define _Bytes_AS_DATA(obj) PyString_AS_STRING(obj)
 #define _Unicode_AS_DATA(obj) PyString_AS_STRING(obj)

--- a/bjoern/py2py3.h
+++ b/bjoern/py2py3.h
@@ -1,0 +1,36 @@
+#ifndef _PY2PY3_H
+#define _PY2PY3_H
+
+#if PY_MAJOR_VERSION >= 3
+#define _Bytes_AS_DATA(obj) PyBytes_AS_STRING(obj)
+#define _Unicode_AS_DATA(obj) PyUnicode_AsUTF8(obj)
+#define _Bytes_FromString(name) PyBytes_FromString(name)
+#define _Unicode_FromString(name) PyUnicode_FromString(name)
+#define _Bytes_FromStringAndSize(data, len) PyBytes_FromStringAndSize(data, len)
+#define _Unicode_FromStringAndSize(data, len) PyUnicode_FromStringAndSize(data, len)
+#define _Bytes_GET_SIZE(obj) PyBytes_GET_SIZE(obj)
+#define _Unicode_GET_SIZE(obj) PyUnicode_GET_LENGTH(obj)
+#define _Bytes_Check(obj) PyBytes_Check(obj)
+#define _Unicode_Check(obj) PyUnicode_Check(obj)
+#define _Bytes_Resize(obj, len) _PyBytes_Resize(obj, len);
+#define _Unicode_Resize(obj, len) PyUnicode_Resize(obj, len);
+#define _FromLong(n) PyLong_FromLong(n)
+#define _File_Check(file) 1 /* To Be Fixed */
+#else
+#define _Bytes_AS_DATA(obj) PyString_AS_STRING(obj)
+#define _Unicode_AS_DATA(obj) PyString_AS_STRING(obj)
+#define _Bytes_FromString(name) PyString_FromString(name)
+#define _Unicode_FromString(name) PyString_FromString(name)
+#define _Bytes_FromStringAndSize(data, len) PyString_FromStringAndSize(data, len)
+#define _Unicode_FromStringAndSize(data, len) PyString_FromStringAndSize(data, len)
+#define _Bytes_GET_SIZE(obj) PyString_GET_SIZE(obj)
+#define _Unicode_GET_SIZE(obj) PyString_GET_SIZE(obj)
+#define _Bytes_Check(obj) PyString_Check(obj)
+#define _Unicode_Check(obj) PyString_Check(obj)
+#define _Bytes_Resize(obj, len) _PyString_Resize(obj, len)
+#define _Unicode_Resize(obj, len) _PyString_Resize(obj, len)
+#define _FromLong(n) PyInt_FromLong(n)
+#define _File_Check(file) PyFile_Check(file)
+#endif
+
+#endif /* _PY2PY3_H */

--- a/bjoern/py2py3.h
+++ b/bjoern/py2py3.h
@@ -33,7 +33,7 @@
 #define _Bytes_Resize(obj, len) _PyString_Resize(obj, len)
 #define _Unicode_Resize(obj, len) _PyString_Resize(obj, len)
 #define _FromLong(n) PyInt_FromLong(n)
-#define _File_Check(file, temp_obj) PyFile_Check(file)
+#define _File_Check(file) PyFile_Check(file)
 #endif
 
 #endif /* _PY2PY3_H */

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -4,12 +4,6 @@
 
 #include "py2py3.h"
 
-typedef struct {
-    char *buf;
-    Py_ssize_t pos;
-    int clean;
-} bytesio;
-
 static inline void PyDict_ReplaceKey(PyObject* dict, PyObject* k1, PyObject* k2);
 static PyObject* wsgi_http_header(string header);
 static http_parser_settings parser_settings;

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -244,7 +244,7 @@ on_message_complete(http_parser* parser)
     _set_header_free_value(_wsgi_input, buf); /* return the bytes to wsgi app */
   } else {
     /* Request has no body */
-    _set_header(_wsgi_input, _empty_string);
+    _set_header(_wsgi_input, _empty_bytes);
   }
 
   PyDict_Update(REQUEST->headers, wsgi_base_dict);

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -10,7 +10,6 @@ static http_parser_settings parser_settings;
 static PyObject* wsgi_base_dict = NULL;
 
 static PyObject *IO;
-static PyObject *OBJECT_empty_bytesio;
 
 Request* Request_new(ServerInfo* server_info, int client_fd, const char* client_addr)
 {
@@ -228,11 +227,11 @@ on_message_complete(http_parser* parser)
     PyObject *buf = PyObject_CallMethodObjArgs(body, _seek, _FromLong(0),
 		    NULL);
     Py_DECREF(buf); /* Discard the return value */
-    _set_header_free_value(_wsgi_input, body); /* return the bytes to wsgi app */
   } else {
     /* Request has no body */
-    _set_header(_wsgi_input, OBJECT_empty_bytesio);
+    body = PyObject_CallMethodObjArgs(IO, _BytesIO, NULL);
   }
+  _set_header_free_value(_wsgi_input, body);
 
   PyDict_Update(REQUEST->headers, wsgi_base_dict);
 
@@ -294,7 +293,6 @@ void _initialize_request_module()
 	    /* PyImport_ImportModule should have exception set already */
 	    return;
     }
-    OBJECT_empty_bytesio = PyObject_CallMethodObjArgs(IO, _BytesIO, NULL);
 
   if(wsgi_base_dict == NULL) {
     wsgi_base_dict = PyDict_New();

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -1,8 +1,4 @@
 #include <Python.h>
-#if PY_MAJOR_VERSION >= 3
-#else
-#include <cStringIO.h>
-#endif
 #include "request.h"
 #include "filewrapper.h"
 
@@ -236,10 +232,6 @@ on_message_complete(http_parser* parser)
     ((bytesio*)body)->pos = 0;
   } else {
     /* Request has no body */
-#if PY_MAJOR_VERSION >= 3
-#else
-    _set_header_free_value(_wsgi_input, PycStringIO->NewInput(_empty_string));
-#endif
   }
 
   PyDict_Update(REQUEST->headers, wsgi_base_dict);
@@ -301,10 +293,6 @@ parser_settings = {
 void _initialize_request_module()
 {
   if(wsgi_base_dict == NULL) {
-#if PY_MAJOR_VERSION >=3
-#else
-    PycString_IMPORT;
-#endif
     wsgi_base_dict = PyDict_New();
 
     /* dct['wsgi.file_wrapper'] = FileWrapper */

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -10,7 +10,6 @@ static http_parser_settings parser_settings;
 static PyObject* wsgi_base_dict = NULL;
 
 static PyObject *IO;
-static PyObject *VALUE_zero;
 static PyObject *OBJECT_empty_bytesio;
 
 Request* Request_new(ServerInfo* server_info, int client_fd, const char* client_addr)
@@ -226,7 +225,7 @@ on_message_complete(http_parser* parser)
   PyObject* body = PyDict_GetItem(REQUEST->headers, _wsgi_input);
   if(body) {
     /* first do a seek(0) and then read() returns all data */
-    PyObject *buf = PyObject_CallMethodObjArgs(body, _seek, VALUE_zero,
+    PyObject *buf = PyObject_CallMethodObjArgs(body, _seek, _FromLong(0),
 		    NULL);
     Py_DECREF(buf); /* Discard the return value */
     _set_header_free_value(_wsgi_input, body); /* return the bytes to wsgi app */
@@ -295,7 +294,6 @@ void _initialize_request_module()
 	    /* PyImport_ImportModule should have exception set already */
 	    return;
     }
-    VALUE_zero = _FromLong(0);
     OBJECT_empty_bytesio = PyObject_CallMethodObjArgs(IO, _BytesIO, NULL);
 
   if(wsgi_base_dict == NULL) {

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -192,7 +192,6 @@ on_body(http_parser* parser, const char* data, const size_t len)
     }
     body = PyObject_CallMethodObjArgs(IO, STR_bytesio, NULL);
     if (body == NULL) {
-	    printf("call io.BytesIO failed\n");
 	    return 1;
     }
     _set_header_free_value(_wsgi_input, body);
@@ -302,10 +301,9 @@ parser_settings = {
 
 void _initialize_request_module()
 {
-    printf("Initializing request module ...\n");
     IO = PyImport_ImportModule("io");
     if (IO == NULL) {
-	    printf("ERROR: importing io.BytesIO failed\n");
+	    /* PyImport_ImportModule should have exception set already */
 	    return;
     }
     STR_bytesio = _Unicode_FromString("BytesIO");

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -244,12 +244,7 @@ on_message_complete(http_parser* parser)
     _set_header_free_value(_wsgi_input, buf); /* return the bytes to wsgi app */
   } else {
     /* Request has no body */
-    body = _Bytes_FromString(NULL);
-    if (body == NULL) {
-	    printf("call io.BytesIO failed\n");
-	    return 1;
-    }
-    _set_header_free_value(_wsgi_input, body);
+    _set_header(_wsgi_input, _empty_string);
   }
 
   PyDict_Update(REQUEST->headers, wsgi_base_dict);

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -252,15 +252,15 @@ on_message_complete(http_parser* parser)
 static PyObject*
 wsgi_http_header(string header)
 {
-  int size = header.len+strlen("HTTP_");
+  const char *http_ = "HTTP_";
+  int size = header.len+strlen(http_);
   char dest[size];
   int i = 0;
 
-  dest[i++] = 'H';
-  dest[i++] = 'T';
-  dest[i++] = 'T';
-  dest[i++] = 'P';
-  dest[i++] = '_';
+  while (*(http_ + i) != '\0') {
+	  dest[i] = http_[i];
+	  i++;
+  }
 
   while(header.len--) {
     char c = *header.data++;

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -247,12 +247,9 @@ wsgi_http_header(string header)
   const char *http_ = "HTTP_";
   int size = header.len+strlen(http_);
   char dest[size];
-  int i = 0;
+  int i = 5;
 
-  while (*(http_ + i) != '\0') {
-	  dest[i] = http_[i];
-	  i++;
-  }
+  memcpy(dest, http_, i);
 
   while(header.len--) {
     char c = *header.data++;

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -1,20 +1,23 @@
 #include <Python.h>
+#if PY_MAJOR_VERSION >= 3
+#else
 #include <cStringIO.h>
+#endif
 #include "request.h"
 #include "filewrapper.h"
+
+#include "py2py3.h"
+
+typedef struct {
+    PyObject_HEAD
+    char *buf;
+    Py_ssize_t pos;
+} bytesio;
 
 static inline void PyDict_ReplaceKey(PyObject* dict, PyObject* k1, PyObject* k2);
 static PyObject* wsgi_http_header(string header);
 static http_parser_settings parser_settings;
 static PyObject* wsgi_base_dict = NULL;
-
-/* Non-public type from cStringIO I abuse in on_body */
-typedef struct {
-  PyObject_HEAD
-  char *buf;
-  Py_ssize_t pos, string_size;
-  PyObject *pbuf;
-} Iobject;
 
 Request* Request_new(ServerInfo* server_info, int client_fd, const char* client_addr)
 {
@@ -25,7 +28,7 @@ Request* Request_new(ServerInfo* server_info, int client_fd, const char* client_
 #endif
   request->server_info = server_info;
   request->client_fd = client_fd;
-  request->client_addr = PyString_FromString(client_addr);
+  request->client_addr = _Unicode_FromString(client_addr);
   http_parser_init((http_parser*)&request->parser, HTTP_REQUEST);
   request->parser.parser.data = request;
   Request_reset(request);
@@ -101,11 +104,12 @@ void Request_parse(Request* request, const char* data, const size_t data_len)
     Py_DECREF(val); \
   } while(0)
 
+
 #define _set_header_from_http_header() \
   do { \
     PyObject* key = wsgi_http_header(PARSER->field); \
     if (key) { \
-      _set_header_free_value(key, PyString_FromStringAndSize(PARSER->value.data, PARSER->value.len)); \
+      _set_header_free_value(key, _Unicode_FromStringAndSize(PARSER->value.data, PARSER->value.len)); \
       Py_DECREF(key); \
     } \
   } while(0) \
@@ -124,14 +128,14 @@ on_path(http_parser* parser, const char* path, size_t len)
 {
   if(!(len = unquote_url_inplace((char*)path, len)))
     return 1;
-  _set_header_free_value(_PATH_INFO, PyString_FromStringAndSize(path, len));
+  _set_header_free_value(_PATH_INFO, _Unicode_FromStringAndSize(path, len));
   return 0;
 }
 
 static int
 on_query_string(http_parser* parser, const char* query, size_t len)
 {
-  _set_header_free_value(_QUERY_STRING, PyString_FromStringAndSize(query, len));
+  _set_header_free_value(_QUERY_STRING, _Unicode_FromStringAndSize(query, len));
   return 0;
 }
 
@@ -174,17 +178,18 @@ on_headers_complete(http_parser* parser)
 static int
 on_body(http_parser* parser, const char* data, const size_t len)
 {
-  Iobject* body;
+  bytesio* body;
 
-  body = (Iobject*)PyDict_GetItem(REQUEST->headers, _wsgi_input);
+  body = (bytesio*)PyDict_GetItem(REQUEST->headers, _wsgi_input);
   if(body == NULL) {
     if(!parser->content_length) {
       REQUEST->state.error_code = HTTP_LENGTH_REQUIRED;
       return 1;
     }
-    PyObject* buf = PyString_FromStringAndSize(NULL, parser->content_length);
-    body = (Iobject*)PycStringIO->NewInput(buf);
+    PyObject* buf = _Bytes_FromStringAndSize(NULL, parser->content_length);
+    body = (bytesio *)buf;
     Py_XDECREF(buf);
+    
     if(body == NULL)
       return 1;
     _set_header(_wsgi_input, (PyObject*)body);
@@ -217,7 +222,8 @@ on_message_complete(http_parser* parser)
     _set_header(_REQUEST_METHOD, _GET);
   } else {
     _set_header_free_value(_REQUEST_METHOD,
-      PyString_FromString(http_method_str(parser->method)));
+      _Unicode_FromString(http_method_str(parser->method))
+      );
   }
 
   /* REMOTE_ADDR */
@@ -227,10 +233,13 @@ on_message_complete(http_parser* parser)
   if(body) {
     /* We abused the `pos` member for tracking the amount of data copied from
      * the buffer in on_body, so reset it to zero here. */
-    ((Iobject*)body)->pos = 0;
+    ((bytesio*)body)->pos = 0;
   } else {
     /* Request has no body */
+#if PY_MAJOR_VERSION >= 3
+#else
     _set_header_free_value(_wsgi_input, PycStringIO->NewInput(_empty_string));
+#endif
   }
 
   PyDict_Update(REQUEST->headers, wsgi_base_dict);
@@ -243,31 +252,31 @@ on_message_complete(http_parser* parser)
 static PyObject*
 wsgi_http_header(string header)
 {
-  PyObject* obj = PyString_FromStringAndSize(NULL, header.len+strlen("HTTP_"));
-  char* dest = PyString_AS_STRING(obj);
+  int size = header.len+strlen("HTTP_");
+  char dest[size];
+  int i = 0;
 
-  *dest++ = 'H';
-  *dest++ = 'T';
-  *dest++ = 'T';
-  *dest++ = 'P';
-  *dest++ = '_';
+  dest[i++] = 'H';
+  dest[i++] = 'T';
+  dest[i++] = 'T';
+  dest[i++] = 'P';
+  dest[i++] = '_';
 
   while(header.len--) {
     char c = *header.data++;
     if (c == '_') {
       // CVE-2015-0219
-      Py_DECREF(obj);
       return NULL;
     }
     else if(c == '-')
-      *dest++ = '_';
+      dest[i++] = '_';
     else if(c >= 'a' && c <= 'z')
-      *dest++ = c - ('a'-'A');
+      dest[i++] = c - ('a'-'A');
     else
-      *dest++ = c;
+      dest[i++] = c;
   }
 
-  return obj;
+  return (PyObject *)_Unicode_FromStringAndSize(dest, size);
 }
 
 static inline void
@@ -292,7 +301,10 @@ parser_settings = {
 void _initialize_request_module()
 {
   if(wsgi_base_dict == NULL) {
+#if PY_MAJOR_VERSION >=3
+#else
     PycString_IMPORT;
+#endif
     wsgi_base_dict = PyDict_New();
 
     /* dct['wsgi.file_wrapper'] = FileWrapper */
@@ -313,7 +325,7 @@ void _initialize_request_module()
     PyDict_SetItemString(
       wsgi_base_dict,
       "wsgi.version",
-      PyTuple_Pack(2, PyInt_FromLong(1), PyInt_FromLong(0))
+      PyTuple_Pack(2, _FromLong(1), _FromLong(0))
     );
 
     /* dct['wsgi.url_scheme'] = 'http'
@@ -321,7 +333,7 @@ void _initialize_request_module()
     PyDict_SetItemString(
       wsgi_base_dict,
       "wsgi.url_scheme",
-      PyString_FromString("http")
+      _Unicode_FromString("http")
     );
 
     /* dct['wsgi.errors'] = sys.stderr */

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ bjoern_extension = Extension(
     include_dirs  = ['http-parser', '/usr/include/libev'],
     define_macros = [('WANT_SENDFILE', '1'),
                      ('WANT_SIGINT_HANDLING', '1')],
-    extra_compile_args = ['-fno-strict-aliasing', '-fcommon',
-                          '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',
+    extra_compile_args = ['-fno-strict-aliasing',
+                          '-Wall', '-Wextra', '-Wno-unused-parameter',
                           '-Wno-missing-field-initializers', '-g']
 )
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ bjoern_extension = Extension(
     include_dirs  = ['http-parser', '/usr/include/libev'],
     define_macros = [('WANT_SENDFILE', '1'),
                      ('WANT_SIGINT_HANDLING', '1')],
-    extra_compile_args = ['-std=c99', '-fno-strict-aliasing', '-fcommon',
+    extra_compile_args = ['-std=c11', '-fno-strict-aliasing', '-fcommon',
                           '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',
                           '-Wno-missing-field-initializers', '-g']
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ bjoern_extension = Extension(
     include_dirs  = ['http-parser', '/usr/include/libev'],
     define_macros = [('WANT_SENDFILE', '1'),
                      ('WANT_SIGINT_HANDLING', '1')],
-    extra_compile_args = ['-std=c11', '-fno-strict-aliasing', '-fcommon',
+    extra_compile_args = ['-fno-strict-aliasing', '-fcommon',
                           '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',
                           '-Wno-missing-field-initializers', '-g']
 )

--- a/tests/empty.py
+++ b/tests/empty.py
@@ -1,6 +1,6 @@
 def app(e, s):
     s('200 ok', [])
-    return ''
+    return b''
 
 import bjoern
 bjoern.run(app, '0.0.0.0', 8080)

--- a/tests/fork.py
+++ b/tests/fork.py
@@ -8,11 +8,11 @@ worker_pids = []
 
 def app(environ, start_response):
     start_response('200 OK', [])
-    yield 'Hello world from worker %d' % os.getpid()
+    yield b'Hello world from worker %d' % os.getpid()
 
 
 bjoern.listen(app, '0.0.0.0', 8080)
-for _ in xrange(NUM_WORKERS):
+for _ in range(NUM_WORKERS):
     pid = os.fork()
     if pid > 0:
         # in master
@@ -26,7 +26,7 @@ for _ in xrange(NUM_WORKERS):
         exit()
 
 try:
-    for _ in xrange(NUM_WORKERS):
+    for _ in range(NUM_WORKERS):
         os.wait()
 except KeyboardInterrupt:
     for pid in worker_pids:

--- a/tests/hello.py
+++ b/tests/hello.py
@@ -2,27 +2,26 @@ import bjoern
 from random import choice
 
 def app1(env, sr):
-    print env
+    #print(env)
     sr('200 ok', [('Foo', 'Bar'), ('Blah', 'Blubb'), ('Spam', 'Eggs'), ('Blurg', 'asdasjdaskdasdjj asdk jaks / /a jaksdjkas jkasd jkasdj '),
                   ('asd2easdasdjaksdjdkskjkasdjka', 'oasdjkadk kasdk k k k k k ')])
-    return ['hello', 'world']
+    return [b'hello', b'world']
 
 def app2(env, sr):
-    print env
+    #print(env)
     sr('200 ok', [])
-    return 'hello'
+    return b'hello'
 
 def app3(env, sr):
-    print env
+    #print(env)
     sr('200 abc', [('Content-Length', '12')])
-    yield 'Hello'
-    yield ' World'
-    yield '\n'
+    yield b'Hello'
+    yield b' World'
+    yield b'\n'
 
-def app4(e, s):
-    print e
-    s('200 ok', [])
-    return ['hello\n']
+def app4(e, sr):
+    sr('200 ok', [])
+    return [b'hello there ... \n']
 
 apps = (app1, app2, app3, app4)
 

--- a/tests/huge.py
+++ b/tests/huge.py
@@ -1,10 +1,10 @@
 N = 1024
-CHUNK = 'a' * 1024
+CHUNK = b'a' * 1024
 DATA_LEN = N * len(CHUNK)
 
 class _iter(object):
     def __iter__(self):
-        for i in xrange(N):
+        for i in range(N):
             yield CHUNK
 
 def app(e, s):

--- a/tests/interrupt-during-request.py
+++ b/tests/interrupt-during-request.py
@@ -11,10 +11,10 @@ request_completed = False
 
 def application(environ, start_response):
     start_response('200 ok', [])
-    yield "chunk1"
+    yield b"chunk1"
     os.kill(os.getpid(), signal.SIGINT)
-    yield "chunk2"
-    yield "chunk3"
+    yield b"chunk2"
+    yield b"chunk3"
     global request_completed
     request_completed = True
 

--- a/tests/listen.py
+++ b/tests/listen.py
@@ -3,8 +3,8 @@ import bjoern
 
 def app(environ, start_response):
     start_response('200 OK', [])
-    yield 'Hello world'
-    yield ''
+    yield b'Hello world'
+    yield b''
 
 bjoern.listen(app, '0.0.0.0', 8080)
 bjoern.run()

--- a/tests/reuse_port.py
+++ b/tests/reuse_port.py
@@ -40,7 +40,7 @@ def cmd_test():
 def cmd_app():
     def app(environ, start_response):
         start_response('200 OK', [])
-        return ["Hello from process %d\n" % os.getpid()]
+        return [b"Hello from process %d\n" % os.getpid()]
 
     import bjoern
     bjoern.run(app, "localhost", 8080, True)

--- a/tests/slow_server.py
+++ b/tests/slow_server.py
@@ -8,15 +8,15 @@ def start():
     def return_tuple(environ, start_response):
         start_response('200 OK', [('Content-Type','text/plain')])
         print 'tuple'
-        return ('Hello,', " it's me, ", 'Bob!')
+        return (b'Hello,', b" it's me, ", b'Bob!')
 
     def return_huge_answer(environ, start_response):
         start_response('200 OK', [('Content-Type','text/plain')])
-        return ['x'*(1024*1024)]
+        return [b'x'*(1024*1024)]
 
     def return_404(environ, start_response):
         start_response('404 Not Found', (('Content-Type','text/plain'), ))
-        return "URL %s not found" % environ.get('PATH_INFO', 'UNKNOWN')
+        return b"URL %s not found" % environ.get('PATH_INFO', 'UNKNOWN')
 
     dispatch = {
         '/tuple': return_tuple,

--- a/tests/test_exc_info_reference.py
+++ b/tests/test_exc_info_reference.py
@@ -22,7 +22,7 @@ def app(env, start_response):
         import sys
         x = sys.exc_info()
         start_response('500 error', alist, x)
-    return ['hello']
+    return [b'hello']
 
 import bjoern
 bjoern.run(app, '0.0.0.0', 8080)


### PR DESCRIPTION
Introduced a single header file "py2py3.h" to handle python2/3 difference in
bjoern and enable full python3 support on top of python2 support.

This port heavily referenced the existing bjoern-py3 implementation:
https://github.com/isaiah/bjoern-py3

but removed the bytesio.c/h completely.