### PR TITLE
Fix of #122

### DIFF
--- a/bjoern/_bjoernmodule.c
+++ b/bjoern/_bjoernmodule.c
@@ -32,7 +32,7 @@ run(PyObject* self, PyObject* args)
     }
   }
 
-  _initialize_request_module();
+  _initialize_request_module(&info);
   server_run(&info);
 
   Py_RETURN_NONE;

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -206,11 +206,9 @@ on_message_complete(http_parser* parser)
   if (REQUEST->server_info->host) {
     _set_header(_SERVER_NAME, REQUEST->server_info->host);
     if (REQUEST->server_info->port == Py_None) {
-      _set_header(_SERVER_PORT,
-                  PyUnicode_FromFormat(""));
+      _set_header(_SERVER_PORT, PyUnicode_FromFormat(""));
     } else {
-      _set_header(_SERVER_PORT,
-                  PyUnicode_FromFormat("%i", REQUEST->server_info->port));
+      _set_header(_SERVER_PORT, PyUnicode_FromFormat("%i", REQUEST->server_info->port));
     }
   }
   /* SERVER_NAME is required */

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -205,7 +205,18 @@ on_message_complete(http_parser* parser)
   /* SERVER_NAME and SERVER_PORT */
   if (REQUEST->server_info->host) {
     _set_header(_SERVER_NAME, REQUEST->server_info->host);
-    _set_header(_SERVER_PORT, REQUEST->server_info->port);
+    if (REQUEST->server_info->port == Py_None) {
+      _set_header(_SERVER_PORT,
+                  PyUnicode_FromFormat(""));
+    } else {
+      _set_header(_SERVER_PORT,
+                  PyUnicode_FromFormat("%i", REQUEST->server_info->port));
+    }
+  }
+  /* SERVER_NAME is required */
+  else {
+    _set_header(_SERVER_NAME, PyUnicode_FromFormat(""));
+    _set_header(_SERVER_PORT, PyUnicode_FromFormat(""));
   }
 
   /* REQUEST_METHOD */

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -202,21 +202,6 @@ on_message_complete(http_parser* parser)
   /* SERVER_PROTOCOL (REQUEST_PROTOCOL) */
   _set_header(_SERVER_PROTOCOL, parser->http_minor == 1 ? _HTTP_1_1 : _HTTP_1_0);
 
-  /* SERVER_NAME and SERVER_PORT */
-  if (REQUEST->server_info->host) {
-    _set_header(_SERVER_NAME, REQUEST->server_info->host);
-    if (REQUEST->server_info->port == Py_None) {
-      _set_header(_SERVER_PORT, PyUnicode_FromFormat(""));
-    } else {
-      _set_header(_SERVER_PORT, PyUnicode_FromFormat("%i", REQUEST->server_info->port));
-    }
-  }
-  /* SERVER_NAME is required */
-  else {
-    _set_header(_SERVER_NAME, PyUnicode_FromFormat(""));
-    _set_header(_SERVER_PORT, PyUnicode_FromFormat(""));
-  }
-
   /* REQUEST_METHOD */
   if(parser->method == HTTP_GET) {
     /* I love useless micro-optimizations. */
@@ -294,7 +279,7 @@ parser_settings = {
   on_header_value, on_headers_complete, on_body, on_message_complete
 };
 
-void _initialize_request_module()
+void _initialize_request_module(ServerInfo* server_info)
 {
   IO_module = PyImport_ImportModule("io");
   if (IO_module == NULL) {
@@ -366,5 +351,22 @@ void _initialize_request_module()
       "wsgi.run_once",
       Py_False
     );
+
+    /* dct['SERVER_NAME'] = '...'
+     * dct['SERVER_PORT'] = '...'
+     * Both are required by WSGI specs. */
+    if (server_info->host) {
+      PyDict_SetItemString(wsgi_base_dict, "SERVER_NAME", server_info->host);
+
+      if (server_info->port == Py_None) {
+      PyDict_SetItemString(wsgi_base_dict, "SERVER_PORT", PyUnicode_FromFormat(""));
+      } else {
+        PyDict_SetItemString(wsgi_base_dict, "SERVER_PORT", PyUnicode_FromFormat("%i", server_info->port));
+      }
+     } else {
+      /* SERVER_NAME is required, but not usefull with UNIX type sockets */
+      PyDict_SetItemString(wsgi_base_dict, "SERVER_NAME", PyUnicode_FromFormat(""));
+      PyDict_SetItemString(wsgi_base_dict, "SERVER_PORT", PyUnicode_FromFormat(""));
+    }
   }
 }

--- a/bjoern/request.h
+++ b/bjoern/request.h
@@ -6,7 +6,7 @@
 #include "common.h"
 #include "server.h"
 
-void _initialize_request_module(void);
+void _initialize_request_module(ServerInfo* server_info);
 
 typedef struct {
   unsigned error_code : 2;

--- a/tests/test_wsgi_compliance.py
+++ b/tests/test_wsgi_compliance.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import os
+import time
+
+from multiprocessing import Process
+from wsgiref.validate import validator
+
+try:
+    from http import client as httplib
+except ImportError:  # Py 2
+    import httplib
+
+import bjoern
+
+@validator
+def _app(environ, start_response):
+    start_response("200 OK", [("Content-Type", "text/plain")])
+    return [b"Hello World"]
+
+def _start_server():
+    bjoern.run(_app, 'localhost', 8080)
+
+def test_compliance():
+    p = Process(target=_start_server)
+    p.start()
+
+    time.sleep(3)  # Should be enough for the server to start
+    try:
+        h = httplib.HTTPConnection('localhost', 8080)
+        h.request("GET", "/")
+        response = h.getresponse()
+    finally:
+        p.terminate()
+    
+    assert response.reason == "OK"
+
+
+if __name__ == "__main__":
+    try:
+        test_compliance()
+    except AssertionError:
+        print("Test failed")
+    else:
+        print("Test successful")


### PR DESCRIPTION
As said, the pull request.

If `SERVER_NAME` or `SERVER_PORT` are not, an empty string is set instead.