### PR TITLE
add GIL in ev_io_on_request

### DIFF
--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -128,11 +128,15 @@ ev_io_on_request(struct ev_loop* mainloop, ev_io* watcher, const int events)
     return;
   }
 
+  GIL_LOCK(0);
+
   Request* request = Request_new(
     ((ThreadInfo*)ev_userdata(mainloop))->server_info,
     client_fd,
     inet_ntoa(sockaddr.sin_addr)
   );
+
+  GIL_UNLOCK(0);
 
   DBG_REQ(request, "Accepted client %s:%d on fd %d",
           inet_ntoa(sockaddr.sin_addr), ntohs(sockaddr.sin_port), client_fd);


### PR DESCRIPTION
`Request_new` calls `_Unicode_FromString`, which ends up in `_PyObject_Malloc`, which causes segmentation fault in some cases.

`Warning The GIL must be held when using these functions. `
https://docs.python.org/3/c-api/memory.html#object-allocators

`ev_io_on_read` and `ev_io_on_write` was guarded with GIL, but `ev_io_on_request` were not, so this patch adds this lock.

Backtrace:
```
#0  _PyObject_Alloc (ctx=<optimized out>, elsize=60, nelem=1, use_calloc=0) at Objects/obmalloc.c:1258
#1  _PyObject_Malloc (ctx=<optimized out>, nbytes=60) at Objects/obmalloc.c:1437
#2  0x00007f075359d489 in PyUnicode_New (size=11, maxchar=<optimized out>) at Objects/unicodeobject.c:1281
#3  0x00007f07535cd012 in _PyUnicodeWriter_PrepareInternal (writer=writer@entry=0x7ffc774d8bf0, length=<optimized out>, 
    maxchar=<optimized out>, maxchar@entry=127) at Objects/unicodeobject.c:13534
#4  0x00007f07535cfbcb in PyUnicode_DecodeUTF8Stateful (s=s@entry=0x7f0753bfd6d8 "10.101.0.11", size=11, errors=errors@entry=0x0, 
    consumed=consumed@entry=0x0) at Objects/unicodeobject.c:5034
#5  0x00007f07535d10fe in PyUnicode_FromString (u=u@entry=0x7f0753bfd6d8 "10.101.0.11") at Objects/unicodeobject.c:2077
#6  0x00007f0751b2ffe6 in Request_new (server_info=0x7ffc774d8e00, client_fd=client_fd@entry=8, 
    client_addr=client_addr@entry=0x7f0753bfd6d8 "10.101.0.11") at bjoern/request.c:23
#7  0x00007f0751b30421 in ev_io_on_request (mainloop=0x1033c90, watcher=<optimized out>, events=<optimized out>) at bjoern/server.c:131
#8  0x00007f075191f515 in ev_invoke_pending () from /usr/lib/x86_64-linux-gnu/libev.so.4
#9  0x00007f07519226b7 in ev_run () from /usr/lib/x86_64-linux-gnu/libev.so.4
```
