### PR TITLE
Provide entry point for PasteDeploy interoperability

### DIFF
--- a/bjoern.py
+++ b/bjoern.py
@@ -82,8 +82,3 @@ def run(*args, **kwargs):
                 os.unlink(sock.getsockname())
         sock.close()
         _default_instance = None
-
-def serve_paste(app, global_conf, **kw):
-    kw['port'] = int(kw.get('port', '0')) or False
-    run(app, **kw)
-    return 0

--- a/bjoern.py
+++ b/bjoern.py
@@ -82,3 +82,8 @@ def run(*args, **kwargs):
                 os.unlink(sock.getsockname())
         sock.close()
         _default_instance = None
+
+def serve_paste(app, global_conf, **kw):
+    kw['port'] = int(kw.get('port', '0')) or False
+    run(app, **kw)
+    return 0

--- a/contrib.py
+++ b/contrib.py
@@ -1,0 +1,28 @@
+from bjoern import run
+
+
+def serve_paste(app, global_conf, **kw):
+    """ A handler for PasteDeploy-compatible runners.
+
+    Sample .ini configuration:
+    
+     [server:main]
+     use = egg:bjoern#main
+     host = 127.0.0.1
+     port = 8080
+     reuse_port = True
+    
+    If no host is specified bjoern will bind to all IPv4 IPs (0.0.0.0)
+    If no port is specified, bjoern will use a random port
+    reuse_port defaults to False
+    """
+    # Convert the values from the .ini file to something bjoern can work with
+    host = kw.get('host', '')
+    port = int(kw.get('port', '0')) or False
+    if kw.get('reuse_port', '').lower() in ('1', 'true'):
+        reuse_port = True
+    else:
+        reuse_port = False
+
+    run(app, host, port=port, reuse_port=reuse_port)
+    return 0

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,9 @@ setup(
                     'Programming Language :: Python :: 3',
                     'Topic :: Internet :: WWW/HTTP :: WSGI :: Server'],
     py_modules   = ['bjoern'],
-    ext_modules  = [bjoern_extension]
+    ext_modules  = [bjoern_extension],
+    entry_points = """
+    [paste.server_runner]
+    main = bjoern:serve_paste
+    """,
 )

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
     ext_modules  = [bjoern_extension],
     entry_points = """
     [paste.server_runner]
-    main = bjoern:serve_paste
+    main = contrib:serve_paste
     """,
 )


### PR DESCRIPTION
This small change makes it much easier to run bjoern in an environment that uses Paste-style .ini files to define settings and pipelines.
