### PR TITLE
Return a non-zero exit status when test_wsgi_compliance.py fails

### DIFF
--- a/tests/test_wsgi_compliance.py
+++ b/tests/test_wsgi_compliance.py
@@ -40,6 +40,6 @@ if __name__ == "__main__":
     try:
         test_compliance()
     except AssertionError:
-        print("Test failed")
+        raise SystemExit("Test failed")
     else:
         print("Test successful")


### PR DESCRIPTION
This is helpful for checking if `tests/test_wsgi_compliance.py` failed