### PR TITLE
#162: naïve implementation of 100-continue

### DIFF
--- a/bjoern.py
+++ b/bjoern.py
@@ -56,6 +56,8 @@ def listen(wsgi_app, host, port=None, reuse_port=False,
                            listen_backlog=listen_backlog)
     _default_instance = (sock, wsgi_app)
 
+    return sock
+
 
 def run(*args, **kwargs):
     """

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -14,7 +14,12 @@
 
 typedef struct { char* data; size_t len; } string;
 
-enum http_status { HTTP_BAD_REQUEST = 1, HTTP_LENGTH_REQUIRED, HTTP_SERVER_ERROR };
+enum http_status {
+  HTTP_BAD_REQUEST = 1,
+  HTTP_LENGTH_REQUIRED,
+  HTTP_EXPECTATION_FAILED,
+  HTTP_SERVER_ERROR
+};
 
 size_t unquote_url_inplace(char* url, size_t len);
 void _init_common(void);

--- a/bjoern/py2py3.h
+++ b/bjoern/py2py3.h
@@ -18,6 +18,7 @@
 #define _PEP3333_String_FromFormat(...) PyUnicode_FromFormat(__VA_ARGS__)
 #define _PEP3333_String_GET_SIZE(u) PyUnicode_GET_LENGTH(u)
 #define _PEP3333_String_Concat(u1, u2) PyUnicode_Concat(u1, u2)
+#define _PEP3333_String_CompareWithASCIIString(o, c_str) PyUnicode_CompareWithASCIIString(o, c_str)
 
 #else
 
@@ -52,6 +53,11 @@ static PyObject *_PEP3333_String_Concat(PyObject *l, PyObject *r)
   PyString_Concat(&ret, r);
 
   return ret;
+}
+
+static int _PEP3333_String_CompareWithASCIIString(PyObject *o, const char *c_str)
+{
+  return memcmp(_PEP3333_Bytes_AS_DATA(o), c_str, _PEP3333_Bytes_GET_SIZE(o));
 }
 #endif
 

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -147,6 +147,14 @@ on_header_field(http_parser* parser, const char* field, size_t len)
     return 0;
   }
 
+  /* If `Expect` is encountered, set request->state to notify that the client
+   * expects an "HTTP/1.1 100 Continue" response before it will send the body */
+  if (!strncmp(field, HTTP_EXPECT, len)) {
+    if (parser->http_major > 0 && parser->http_minor > 0) {
+      REQUEST->state.expect_continue = true;
+    }
+  }
+
   char field_processed[len];
   for(size_t i=0; i<len; i++) {
     char c = field[i];

--- a/bjoern/request.h
+++ b/bjoern/request.h
@@ -50,9 +50,6 @@ typedef struct {
 #define REQUEST_FROM_WATCHER(watcher) \
   (Request*)((size_t)watcher - (size_t)(&(((Request*)NULL)->ev_watcher)));
 
-#define HTTP_EXPECT "Expect"
-#define CONTINUE_RESPONSE "HTTP/1.1 100 Continue\r\n\r\n"
-
 Request* Request_new(ServerInfo*, int client_fd, const char* client_addr);
 void Request_parse(Request*, const char*, const size_t);
 void Request_reset(Request*);

--- a/bjoern/request.h
+++ b/bjoern/request.h
@@ -16,6 +16,7 @@ typedef struct {
   unsigned keep_alive : 1;
   unsigned response_length_unknown : 1;
   unsigned chunked_response : 1;
+  unsigned expect_continue : 1;
 } request_state;
 
 typedef struct {
@@ -48,6 +49,9 @@ typedef struct {
 
 #define REQUEST_FROM_WATCHER(watcher) \
   (Request*)((size_t)watcher - (size_t)(&(((Request*)NULL)->ev_watcher)));
+
+#define HTTP_EXPECT "Expect"
+#define CONTINUE_RESPONSE "HTTP/1.1 100 Continue\r\n\r\n"
 
 Request* Request_new(ServerInfo*, int client_fd, const char* client_addr);
 void Request_parse(Request*, const char*, const size_t);

--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -29,13 +29,17 @@ static const char* http_error_messages[4] = {
   NULL, /* Error codes start at 1 because 0 means "no error" */
   "HTTP/1.1 400 Bad Request\r\n\r\n",
   "HTTP/1.1 406 Length Required\r\n\r\n",
+  "HTTP/1.1 417 Expectation Failed\r\n\r\n",
   "HTTP/1.1 500 Internal Server Error\r\n\r\n"
 };
+
+static const char *CONTINUE = "HTTP/1.1 100 Continue\r\n\r\n";
 
 enum _rw_state {
   not_yet_done = 1,
   done,
   aborted,
+  expect_continue,
 };
 typedef enum _rw_state read_state;
 typedef enum _rw_state write_state;
@@ -172,6 +176,23 @@ ev_io_on_request(struct ev_loop* mainloop, ev_io* watcher, const int events)
   ev_io_start(mainloop, &request->ev_watcher);
 }
 
+
+static void
+start_reading(struct ev_loop *mainloop, Request *request)
+{
+  ev_io_init(&request->ev_watcher, &ev_io_on_read,
+             request->client_fd, EV_READ);
+  ev_io_start(mainloop, &request->ev_watcher);
+}
+
+static void
+start_writing(struct ev_loop *mainloop, Request *request)
+{
+  ev_io_init(&request->ev_watcher, &ev_io_on_write,
+             request->client_fd, EV_WRITE);
+  ev_io_start(mainloop, &request->ev_watcher);
+}
+
 static void
 ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
 {
@@ -211,10 +232,11 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
         http_error_messages[request->state.error_code]);
       assert(request->iterator == NULL);
     } else if(request->state.parse_finished) {
-      /* HTTP parse successful */
+      /* HTTP parse successful, meaning we have the entire
+       * request (the header _and_ the body). */
       read_state = done;
-      bool wsgi_ok = wsgi_call_application(request);
-      if (!wsgi_ok) {
+
+      if (!wsgi_call_application(request)) {
         /* Response is "HTTP 500 Internal Server Error" */
         DBG_REQ(request, "WSGI app error");
         assert(PyErr_Occurred());
@@ -225,10 +247,12 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
           http_error_messages[HTTP_SERVER_ERROR]);
       }
     } else if (request->state.expect_continue) {
-      read_state = done;
-      request->current_chunk = _PEP3333_Bytes_FromString(
-        CONTINUE_RESPONSE);
-      request->state.keep_alive = true;
+      /*
+      ** Handle "Expect: 100-continue" header.
+      ** See https://tools.ietf.org/html/rfc2616#page-48 and `on_header_value`
+      ** in request.c for more details.
+      */
+      read_state = expect_continue;
     } else {
       /* Wait for more data */
       read_state = not_yet_done;
@@ -238,12 +262,16 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
   switch (read_state) {
   case not_yet_done:
     break;
+  case expect_continue:
+    DBG_REQ(request, "pause read, write 100-continue");
+    ev_io_stop(mainloop, &request->ev_watcher);
+    request->current_chunk = _PEP3333_Bytes_FromString(CONTINUE);
+    start_writing(mainloop, request);
+    break;
   case done:
     DBG_REQ(request, "Stop read watcher, start write watcher");
     ev_io_stop(mainloop, &request->ev_watcher);
-    ev_io_init(&request->ev_watcher, &ev_io_on_write,
-               request->client_fd, EV_WRITE);
-    ev_io_start(mainloop, &request->ev_watcher);
+    start_writing(mainloop, request);
     break;
   case aborted:
     close_connection(mainloop, request);
@@ -283,6 +311,10 @@ ev_io_on_write(struct ev_loop* mainloop, ev_io* watcher, const int events)
     write_state = on_write_chunk(mainloop, request);
   }
 
+  write_state = request->state.expect_continue
+    ? expect_continue
+    : write_state;
+
   switch(write_state) {
   case not_yet_done:
     break;
@@ -291,22 +323,21 @@ ev_io_on_write(struct ev_loop* mainloop, ev_io* watcher, const int events)
       DBG_REQ(request, "done, keep-alive");
       ev_io_stop(mainloop, &request->ev_watcher);
 
-      if (!request->state.expect_continue) {
-        /* There will be more to receive/send after sending 100-Continue, so
-         * don't clobber the request until after the "real" response. */
-        Request_clean(request);
-        Request_reset(request);
-      }
+      Request_clean(request);
+      Request_reset(request);
 
-      request->state.expect_continue = false;
-
-      ev_io_init(&request->ev_watcher, &ev_io_on_read,
-                 request->client_fd, EV_READ);
-      ev_io_start(mainloop, &request->ev_watcher);
+      start_reading(mainloop, request);
     } else {
       DBG_REQ(request, "done, close");
       close_connection(mainloop, request);
     }
+    break;
+  case expect_continue:
+    DBG_REQ(request, "expect continue");
+    ev_io_stop(mainloop, &request->ev_watcher);
+
+    request->state.expect_continue = false;
+    start_reading(mainloop, request);
     break;
   case aborted:
     /* Response was aborted due to an error. We can't do anything graceful here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/tests/expect100.py
+++ b/tests/expect100.py
@@ -1,43 +1,87 @@
 from __future__ import print_function
-import bjoern, socket, threading, time, json, sys, requests
-
-
-responses = 0
+import bjoern, socket, threading, time, json, sys, requests, logging
 
 
 def app(e, s):
-    s('200 OK', [("Content-Length", "14")])
-    return b"hello response"
+    s('200 OK', [("Content-Length", "0")])
+    return b""
 
 
-def make_request(host, port, reports, i):
-    global responses
+def record_report(reports, request, resp):
+    reports.append({"request": request, "response": resp.decode("utf-8")})
 
-    content_length = 1 << i
+
+def expect_100_continue(test_num, i, request, resp, reports, client, content_length):
+    if resp == b"HTTP/1.1 100 Continue\r\n\r\n":
+        body = "".join("x" for x in range(0, content_length))
+
+        logging.debug("Request body for test {}, iteration {}: {}".format(test_num, i, body))
+
+        client.send(body.encode("utf-8"))
+
+        logging.info("Request body sent for test {}, iteration {}".format(test_num, i))
+
+        resp = client.recv(1 << 10)
+
+        logging.info("Response 2 for test, {}, iteration {}".format(test_num, i))
+    else:
+        record_report(reports, request, resp)
+
+
+def expect_417_expectation_failed(test_num, i, request, resp, reports, *args):
+    if resp != b"HTTP/1.1 417 Expectation Failed\r\n\r\n":
+        record_report(reports, request, resp)
+
+
+def expect_200_ok(test_num, i, request, resp, reports, *args):
+    if resp != b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: Keep-Alive\r\n\r\n":
+        record_report(reports, request, resp)
+
+
+def make_request(host, port, reports, responses, test_num, i,
+                 expectation="100-continue", assertion=expect_100_continue,
+                 body=None):
+
+    content_length = 1 << i if not body else len(body)
     client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     client.connect((host, port))
     request = ("GET /{} HTTP/1.1\r\n"
-               "Accept: */*\r\n"
-               "Expect: 100-continue\r\n"
-               "Content-Length: {}\r\n\r\n").format(i, content_length)
+               "Expect: {}\r\n"
+               "Content-Length: {}\r\n\r\n").format(i, expectation, content_length)
 
+    if body is not None:
+        request = "{}{}".format(request, body)
+
+    logging.info("Request for test {}, iteration {}: {}".format(test_num, i, request))
     client.send(request.encode("utf-8"))
-    print("Request for iteration {}".format(i))
+
+    logging.info("Request sent for test {}, iteration {}".format(test_num, i))
     resp = client.recv(1 << 10)
 
-    if resp == b"HTTP/1.1 100 Continue\r\n\r\n":
-        client.send("".join("x" for x in range(0, content_length)).encode("utf-8"))
-        resp = client.recv(1 << 10)
-        reports.append({"request": request, "response": resp.decode("utf-8")})
+    logging.info("Response 1 for test {}, iteration {}".format(test_num, i))
+
+    assertion(test_num, i, request, resp, reports, client, content_length)
 
     client.close()
 
-    print("Response for iteration {}".format(i))
-    responses = responses + 1
+    logging.info("Response recv'ed for test {}, iteration {}".format(test_num, i))
+    responses.append(resp)
+
+
+def usage():
+    print("usage: python {} $iterations $log_level".format(sys.argv[0]))
 
 
 if __name__ == "__main__":
+
+    if len(sys.argv) > 1 and sys.argv[1] in {"-h", "--help"}:
+        usage()
+        sys.exit(0)
+
+    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+    level = getattr(logging, sys.argv[2].upper()) if len(sys.argv) > 2 else logging.WARNING
+
     host, port = "0.0.0.0", 8081
     sock = bjoern.listen(app, host, port, reuse_port=True)
 
@@ -46,17 +90,36 @@ if __name__ == "__main__":
     t.start()
 
     reports = []
-    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+    responses = []
 
-    for i in range(0, iterations):
-        t = threading.Thread(target=make_request, args=[host, port, reports, i + 1])
-        t.setDaemon(True)
-        t.start()
+    tests = [
+        {"expectation": "100-continue", "assertion": expect_100_continue},
+        {"expectation": "100-continue", "assertion": expect_100_continue, "body": ""},
+        {"expectation": "badness", "assertion": expect_417_expectation_failed},
+        {"expectation": "100-continue", "assertion": expect_200_ok, "body": "test"},
+        {"expectation": "badness", "assertion": expect_417_expectation_failed, "body": "test"}
+    ]
 
-    while responses < iterations:
-        time.sleep(1)
+    logging.basicConfig(
+        level=level,
+        format='%(name)s - %(levelname)s - %(message)s'
+    )
 
-    if len(reports) < iterations:
-        print(json.dumps(reports), file=sys.stderr)
+    for idx, test in enumerate(tests):
+        request_count = iterations * (idx + 1)
+
+        for i in range(0, iterations):
+            t = threading.Thread(
+                target=make_request,
+                args=[host, port, reports, responses, idx + 1, i + 1],
+                kwargs=test
+            )
+            t.start()
+
+        while len(responses) < request_count:
+            time.sleep(1)
+
+    if reports:
+        logging.error(json.dumps(reports, indent=4))
         sys.exit(1)
 

--- a/tests/expect100.py
+++ b/tests/expect100.py
@@ -1,0 +1,62 @@
+from __future__ import print_function
+import bjoern, socket, threading, time, json, sys, requests
+
+
+responses = 0
+
+
+def app(e, s):
+    s('200 OK', [("Content-Length", "14")])
+    return b"hello response"
+
+
+def make_request(host, port, reports, i):
+    global responses
+
+    content_length = 1 << i
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    client.connect((host, port))
+    request = ("GET /{} HTTP/1.1\r\n"
+               "Accept: */*\r\n"
+               "Expect: 100-continue\r\n"
+               "Content-Length: {}\r\n\r\n").format(i, content_length)
+
+    client.send(request.encode("utf-8"))
+    print("Request for iteration {}".format(i))
+    resp = client.recv(1 << 10)
+
+    if resp == b"HTTP/1.1 100 Continue\r\n\r\n":
+        client.send("".join("x" for x in range(0, content_length)).encode("utf-8"))
+        resp = client.recv(1 << 10)
+        reports.append({"request": request, "response": resp.decode("utf-8")})
+
+    client.close()
+
+    print("Response for iteration {}".format(i))
+    responses = responses + 1
+
+
+if __name__ == "__main__":
+    host, port = "0.0.0.0", 8081
+    sock = bjoern.listen(app, host, port, reuse_port=True)
+
+    t = threading.Thread(target=bjoern.server_run, args=[sock, app])
+    t.setDaemon(True)
+    t.start()
+
+    reports = []
+    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+
+    for i in range(0, iterations):
+        t = threading.Thread(target=make_request, args=[host, port, reports, i + 1])
+        t.setDaemon(True)
+        t.start()
+
+    while responses < iterations:
+        time.sleep(1)
+
+    if len(reports) < iterations:
+        print(json.dumps(reports), file=sys.stderr)
+        sys.exit(1)
+


### PR DESCRIPTION
This is my first Python C extension development experience, and frankly I don't work with C very often, but I thought this would be a fun way to practice.

So if you have time and don't mind reviewing this, I would love to know what could be improved, etc.

I didn't see a good way to implement option 2 in the PEP 3333 suggested mechanisms for handling Expect/Continue, so I went with option 1 (i.e., if Expect is encountered and the value is "100-continue", just go ahead and write it). It would probably be better to allow the client code to make this determination, but, although we could pass the `client_fd` as a PyFile to the client, it doesn't really have access to the header until the entire request is parsed, and by that time, it's too late. Please correct me if I'm wrong.

Thanks!