### PR TITLE
Add statsd metrics on server events

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
   path = http-parser
   url = git://github.com/joyent/http-parser
 [submodule "statsd-c-client"]
-	path = statsd-c-client
-	url = git@github.com:romanbsd/statsd-c-client.git
+  path = statsd-c-client
+  url = https://github.com/romanbsd/statsd-c-client

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "http-parser"]
   path = http-parser
   url = git://github.com/joyent/http-parser
+[submodule "statsd-c-client"]
+	path = statsd-c-client
+	url = git@github.com:romanbsd/statsd-c-client.git

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,15 @@ HTTP_PARSER_DIR	= http-parser
 HTTP_PARSER_OBJ = $(HTTP_PARSER_DIR)/http_parser.o
 HTTP_PARSER_SRC = $(HTTP_PARSER_DIR)/http_parser.c
 
-objects		= $(HTTP_PARSER_OBJ) \
+STATSD_CLIENT_DIR = statsd-c-client
+STATSD_CLIENT_OBJ = $(STATSD_CLIENT_DIR)/statsd-client.o
+STATSD_CLIENT_SRC = $(STATSD_CLIENT_DIR)/statsd-client.c
+
+objects		= $(HTTP_PARSER_OBJ) $(STATSD_CLIENT_OBJ) \
 		  $(patsubst $(SOURCE_DIR)/%.c, $(BUILD_DIR)/%.o, \
 		             $(wildcard $(SOURCE_DIR)/*.c))
 
-CPPFLAGS	+= $(PYTHON_INCLUDE) -I . -I $(SOURCE_DIR) -I $(HTTP_PARSER_DIR)
+CPPFLAGS	+= $(PYTHON_INCLUDE) -I . -I $(SOURCE_DIR) -I $(HTTP_PARSER_DIR) -I $(STATSD_CLIENT_DIR)
 CFLAGS		+= $(FEATURES) -std=c99 -fno-strict-aliasing -fcommon -fPIC -Wall
 LDFLAGS		+= $(PYTHON_LDFLAGS) -l ev -shared -fcommon
 
@@ -107,3 +111,6 @@ upload:
 
 $(HTTP_PARSER_OBJ):
 	$(MAKE) -C $(HTTP_PARSER_DIR) http_parser.o CFLAGS_DEBUG_EXTRA=-fPIC CFLAGS_FAST_EXTRA=-fPIC
+
+$(STATSD_CLIENT_OBJ):
+	$(MAKE) -C $(STATSD_CLIENT_DIR) statsd-client.o CFLAGS_DEBUG_EXTRA=-fPIC CFLAGS_FAST_EXTRA=-fPIC

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,6 @@ CPPFLAGS	+= $(PYTHON_INCLUDE) -I . -I $(SOURCE_DIR) -I $(HTTP_PARSER_DIR) -I $(S
 CFLAGS		+= $(FEATURES) -std=c99 -fno-strict-aliasing -fcommon -fPIC -Wall
 LDFLAGS		+= $(PYTHON_LDFLAGS) -l ev -shared -fcommon
 
-ifneq ($(WANT_SENDFILE), no)
-FEATURES	+= -D WANT_SENDFILE
-endif
-
 ifneq ($(WANT_SIGINT_HANDLING), no)
 FEATURES	+= -D WANT_SIGINT_HANDLING
 endif

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ ifneq ($(WANT_STATSD), no)
 FEATURES	+= -D WANT_STATSD
 endif
 
+ifneq ($(WANT_STATSD_TAGS), no)
+FEATURES	+= -D WANT_STATSD_TAGS
+endif
+
 all: prepare-build $(objects) _bjoernmodule
 
 print-env:

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ ifndef SIGNAL_CHECK_INTERVAL
 FEATURES	+= -D SIGNAL_CHECK_INTERVAL=0.1
 endif
 
-ifneq ($(WANT_STATSD), no)
+ifeq ($(WANT_STATSD), yes)
 FEATURES	+= -D WANT_STATSD
 endif
 
-ifneq ($(WANT_STATSD_TAGS), no)
+ifeq ($(WANT_STATSD_TAGS), yes)
 FEATURES	+= -D WANT_STATSD_TAGS
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ ifndef SIGNAL_CHECK_INTERVAL
 FEATURES	+= -D SIGNAL_CHECK_INTERVAL=0.1
 endif
 
+ifneq ($(WANT_STATSD), no)
+FEATURES	+= -D WANT_STATSD
+endif
+
 all: prepare-build $(objects) _bjoernmodule
 
 print-env:

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ _bjoernmodule:
 again: clean all
 
 debug:
-	CFLAGS='-D DEBUG -g' make again
+	CFLAGS='${CFLAGS} -D DEBUG -g' make again
 
 $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c
 	@echo ' -> ' $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@

--- a/README.rst
+++ b/README.rst
@@ -42,16 +42,24 @@ Usage
    # Bind to abstract Unix socket: (Linux only)
    bjoern.run(wsgi_application, 'unix:@socket_name')
 
+   # enable statsd metrics
+   bjoern.run(wsgi_application, host, port, reuse_port=True, enable_statsd=True)
+
 Alternatively, the mainloop can be run separately::
 
    bjoern.listen(wsgi_application, host, port)
    bjoern.run()
-   
+
+   # with metrics
+   bjoern.listen(wsgi_application, host, port)
+   bjoern.run(enable_statsd=True)
+
 You can also simply pass a Python socket(-like) object. Note that you are responsible
 for initializing and cleaning up the socket in that case. ::
 
    bjoern.server_run(socket_object, wsgi_application)
    bjoern.server_run(filedescriptor_as_integer, wsgi_application)
+   bjoern.server_run(socket_object, wsgi_application, enable_statsd=True)
 
 .. _WSGI:         http://www.python.org/dev/peps/pep-0333/
 .. _libev:        http://software.schmorp.de/pkg/libev.html

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Usage
    bjoern.run(wsgi_application, 'unix:@socket_name')
 
    # enable statsd metrics
+   # This needs manual compilation with `WANT_STATSD=yes`
    bjoern.run(wsgi_application, host, port, reuse_port=True, enable_statsd=True)
 
 Alternatively, the mainloop can be run separately::
@@ -51,6 +52,7 @@ Alternatively, the mainloop can be run separately::
    bjoern.run()
 
    # with metrics
+   # This needs manual compilation with `WANT_STATSD=yes`
    bjoern.listen(wsgi_application, host, port)
    bjoern.run(enable_statsd=True)
 
@@ -59,6 +61,8 @@ for initializing and cleaning up the socket in that case. ::
 
    bjoern.server_run(socket_object, wsgi_application)
    bjoern.server_run(filedescriptor_as_integer, wsgi_application)
+
+   # This needs manual compilation with `WANT_STATSD=yes`
    bjoern.server_run(socket_object, wsgi_application, enable_statsd=True)
 
 .. _WSGI:         http://www.python.org/dev/peps/pep-0333/

--- a/bjoern.py
+++ b/bjoern.py
@@ -6,6 +6,7 @@ import _bjoern
 _default_instance = None
 DEFAULT_LISTEN_BACKLOG = 1024
 
+features = _bjoern.features
 
 def bind_and_listen(host, port=None, reuse_port=False,
                     listen_backlog=DEFAULT_LISTEN_BACKLOG):
@@ -36,10 +37,15 @@ def bind_and_listen(host, port=None, reuse_port=False,
 
 
 def server_run(sock, wsgi_app, statsd=None):
-    if statsd is None:
-        _bjoern.server_run(sock, wsgi_app)
-    else:
-        _bjoern.server_run(sock, wsgi_app, int(statsd['enable']), statsd['host'], statsd['port'], statsd['ns'], statsd.get('tags'))
+    args = [sock, wsgi_app]
+
+    if statsd and features.get('has_statsd'):
+        args.extend([int(statsd['enable']), statsd['host'], statsd['port'], statsd['ns'], statsd.get('tags')])
+
+    if not statsd and features.get('has_statsd'):
+        args.extend([0, None, 0, None, None])
+
+    _bjoern.server_run(*args)
 
 
 def listen(wsgi_app, host, port=None, reuse_port=False,

--- a/bjoern.py
+++ b/bjoern.py
@@ -35,8 +35,12 @@ def bind_and_listen(host, port=None, reuse_port=False,
     return sock
 
 
-def server_run(sock, wsgi_app, enable_statsd=False, statsd_host="127.0.0.1", statsd_port=8125, statsd_ns="bjoern"):
-    _bjoern.server_run(sock, wsgi_app, int(enable_statsd), statsd_host, statsd_port, statsd_ns)
+def server_run(sock, wsgi_app, enable_statsd=False, statsd_host="127.0.0.1", statsd_port=8125, statsd_ns="bjoern", statsd_tags=None):
+    tags = None
+    if statsd_tags:
+        tags = ",".join(statsd_tags)
+
+    _bjoern.server_run(sock, wsgi_app, int(enable_statsd), statsd_host, statsd_port, statsd_ns, tags)
 
 
 # Backwards compatibility API
@@ -65,6 +69,7 @@ def __separate_config(kwargs):
         "statsd_host": "127.0.0.1",
         "statsd_port": 8125,
         "statsd_ns": "bjoern",
+        "statsd_tags": [],
     }
 
     for each in statsd_config.keys():

--- a/bjoern.py
+++ b/bjoern.py
@@ -6,8 +6,6 @@ import _bjoern
 _default_instance = None
 DEFAULT_LISTEN_BACKLOG = 1024
 
-features = _bjoern.features
-
 def bind_and_listen(host, port=None, reuse_port=False,
                     listen_backlog=DEFAULT_LISTEN_BACKLOG):
     if host.startswith("unix:@"):
@@ -39,11 +37,11 @@ def bind_and_listen(host, port=None, reuse_port=False,
 def server_run(sock, wsgi_app, statsd=None):
     args = [sock, wsgi_app]
 
-    if statsd and features.get('has_statsd'):
-        args.extend([int(statsd['enable']), statsd['host'], statsd['port'], statsd['ns'], statsd.get('tags')])
-
-    if not statsd and features.get('has_statsd'):
-        args.extend([0, None, 0, None, None])
+    if _bjoern.features.get('has_statsd'):
+        if statsd:
+            args.extend([int(statsd['enable']), statsd['host'], statsd['port'], statsd['ns'], statsd.get('tags')])
+        else:
+            args.extend([0, None, 0, None, None])
 
     _bjoern.server_run(*args)
 

--- a/bjoern/_bjoernmodule.c
+++ b/bjoern/_bjoernmodule.c
@@ -17,9 +17,9 @@ run(PyObject* self, PyObject* args)
 #ifdef WANT_STATSD
   info.statsd = NULL;
   int statsd_enabled;
-  char* statsd_host = NULL;
+  char* statsd_host;
   int statsd_port;
-  char* statsd_ns = NULL;
+  char* statsd_ns;
   char* statsd_tags = NULL;
 
   if(!PyArg_ParseTuple(args, "OOiziz|z:server_run", &socket, &info.wsgi_app,
@@ -27,11 +27,15 @@ run(PyObject* self, PyObject* args)
     return NULL;
   }
 #else
-  char* ignored_str;
-  int ignored_int;
+  char* ignored_str = NULL;
+  int ignored_int = 0;
 
   if(!PyArg_ParseTuple(args, "OO|izizz:server_run", &socket, &info.wsgi_app, &ignored_int,
                        &ignored_str, &ignored_int, &ignored_str, &ignored_str)) {
+    return NULL;
+  }
+  if (ignored_str != NULL || ignored_int != 0) {
+    PyErr_Format(PyExc_TypeError, "Unexpected statsd_* arguments (forgot to compile with statsd support?)");
     return NULL;
   }
 #endif

--- a/bjoern/_bjoernmodule.c
+++ b/bjoern/_bjoernmodule.c
@@ -123,16 +123,44 @@ PyMODINIT_FUNC INIT_BJOERN(void)
   Py_INCREF(&FileWrapper_Type);
   Py_INCREF(&StartResponse_Type);
 
+  PyObject* features = PyDict_New();
+
+#ifdef WANT_SIGNAL_HANDLING
+  PyDict_SetItemString(features, "has_signal_handling", Py_True);
+#else
+  PyDict_SetItemString(features, "has_signal_handling", Py_False);
+#endif
+
+#ifdef WANT_SIGINT_HANDLING
+  PyDict_SetItemString(features, "has_sigint_handling", Py_True);
+#else
+  PyDict_SetItemString(features, "has_sigint_handling", Py_False);
+#endif
+
+#ifdef WANT_STATSD
+  PyDict_SetItemString(features, "has_statsd", Py_True);
+#else
+  PyDict_SetItemString(features, "has_statsd", Py_False);
+#endif
+
+#ifdef WANT_STATSD_TAGS
+  PyDict_SetItemString(features, "has_statsd_tags", Py_True);
+#else
+  PyDict_SetItemString(features, "has_statsd_tags", Py_False);
+#endif
+
 #if PY_MAJOR_VERSION >= 3
   PyObject* bjoern_module = PyModule_Create(&module);
   if (bjoern_module == NULL) {
     return NULL;
   }
 
+  PyModule_AddObject(bjoern_module, "features", features);
   PyModule_AddObject(bjoern_module, "version", Py_BuildValue("(iii)", 3, 0, 1));
   return bjoern_module;
 #else
   PyObject* bjoern_module = Py_InitModule("_bjoern", Bjoern_FunctionTable);
+  PyModule_AddObject(bjoern_module, "features", features);
   PyModule_AddObject(bjoern_module, "version", Py_BuildValue("(iii)", 3, 0, 1));
 #endif
 

--- a/bjoern/_bjoernmodule.c
+++ b/bjoern/_bjoernmodule.c
@@ -69,11 +69,16 @@ run(PyObject* self, PyObject* args)
       } else {
         info.statsd = statsd_init_with_namespace(statsd_host, statsd_port, statsd_ns);
       }
+#ifdef WANT_STATSD_TAGS
+      info.statsd_tags = statsd_tags;
+      DBG("Statsd: host=%s, port=%d, ns=%s, tags=%s", statsd_host, statsd_port, statsd_ns, statsd_tags);
+#else
+      DBG("Statsd: host=%s, port=%d, ns=%s", statsd_host, statsd_port, statsd_ns);
+#endif
+  } else {
+      DBG("Statsd disabled");
   }
 
-#ifdef WANT_STATSD_TAGS
-  info.statsd_tags = statsd_tags;
-#endif
 
 #endif
 
@@ -154,14 +159,14 @@ PyMODINIT_FUNC INIT_BJOERN(void)
   if (bjoern_module == NULL) {
     return NULL;
   }
-
-  PyModule_AddObject(bjoern_module, "features", features);
-  PyModule_AddObject(bjoern_module, "version", Py_BuildValue("(iii)", 3, 0, 1));
-  return bjoern_module;
 #else
   PyObject* bjoern_module = Py_InitModule("_bjoern", Bjoern_FunctionTable);
-  PyModule_AddObject(bjoern_module, "features", features);
-  PyModule_AddObject(bjoern_module, "version", Py_BuildValue("(iii)", 3, 0, 1));
 #endif
 
+  PyModule_AddObject(bjoern_module, "features", features);
+  PyModule_AddObject(bjoern_module, "version", Py_BuildValue("(iii)", 3, 0, 1));
+
+#if PY_MAJOR_VERSION >= 3
+  return bjoern_module;
+#endif
 }

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -62,11 +62,19 @@ PyObject *_REMOTE_ADDR, *_PATH_INFO, *_QUERY_STRING, *_REQUEST_METHOD, *_GET,
 
   #ifdef WANT_STATSD_TAGS
     #include "statsd_tags.h"
-    #define STATSD_INCREMENT(name) statsd_inc_with_tags(((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd, \
-                                                        name, \
-                                                        ((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd_tags)
+    #define STATSD_INCREMENT(name) \
+      do { \
+        DBG("statisd.inc: %s", name); \
+        statsd_inc_with_tags(((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd, \
+                             name, \
+                             ((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd_tags); \
+      } while (0)
   #else
-    #define STATSD_INCREMENT(name) statsd_inc(((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd, name, 1.0)
+    #define STATSD_INCREMENT(name) \
+      do { \
+        DBG("statisd.inc: %s", name); \
+        statsd_inc(((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd, name, 1.0); \
+      } while (0)
   #endif
 #else
   #define STATSD_INCREMENT(name) DBG("statsd.inc: %s", name)

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -59,7 +59,13 @@ PyObject *_REMOTE_ADDR, *_PATH_INFO, *_QUERY_STRING, *_REQUEST_METHOD, *_GET,
 
 #ifdef WANT_STATSD
   #include "statsd-client.h"
-  #define STATSD_INC(name) statsd_inc(((ThreadInfo*) ev_userdata(mainloop))->statsd, name, 1.0)
+
+  #ifdef WANT_STATSD_TAGS
+    #include "statsd_tags.h"
+    #define STATSD_INC(name) statsd_inc_with_tags(((ThreadInfo*) ev_userdata(mainloop))->statsd, name, ((ThreadInfo*) ev_userdata(mainloop))->statsd_tags)
+  #else
+    #define STATSD_INC(name) statsd_inc(((ThreadInfo*) ev_userdata(mainloop))->statsd, name, 1.0)
+  #endif
 #else
   #define STATSD_INC(name) DBG("statsd.inc: %s", name)
 #endif

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -57,4 +57,11 @@ PyObject *_REMOTE_ADDR, *_PATH_INFO, *_QUERY_STRING, *_REQUEST_METHOD, *_GET,
   #define assert(...) do{}while(0)
 #endif
 
+#ifdef WANT_STATSD
+  #include "statsd-client.h"
+  #define STATSD_INC(name) statsd_inc(((ThreadInfo*) ev_userdata(mainloop))->statsd, name, 1.0)
+#else
+  #define STATSD_INC(name) DBG("statsd.inc: %s", name)
+#endif
+
 #endif

--- a/bjoern/common.h
+++ b/bjoern/common.h
@@ -62,12 +62,14 @@ PyObject *_REMOTE_ADDR, *_PATH_INFO, *_QUERY_STRING, *_REQUEST_METHOD, *_GET,
 
   #ifdef WANT_STATSD_TAGS
     #include "statsd_tags.h"
-    #define STATSD_INC(name) statsd_inc_with_tags(((ThreadInfo*) ev_userdata(mainloop))->statsd, name, ((ThreadInfo*) ev_userdata(mainloop))->statsd_tags)
+    #define STATSD_INCREMENT(name) statsd_inc_with_tags(((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd, \
+                                                        name, \
+                                                        ((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd_tags)
   #else
-    #define STATSD_INC(name) statsd_inc(((ThreadInfo*) ev_userdata(mainloop))->statsd, name, 1.0)
+    #define STATSD_INCREMENT(name) statsd_inc(((ThreadInfo*) ev_userdata(mainloop))->server_info->statsd, name, 1.0)
   #endif
 #else
-  #define STATSD_INC(name) DBG("statsd.inc: %s", name)
+  #define STATSD_INCREMENT(name) DBG("statsd.inc: %s", name)
 #endif
 
 #endif

--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -54,12 +54,12 @@ typedef struct {
 
 typedef void ev_io_callback(struct ev_loop*, ev_io*, const int);
 
-#if WANT_SIGINT_HANDLING
+#ifdef WANT_SIGINT_HANDLING
 typedef void ev_signal_callback(struct ev_loop*, ev_signal*, const int);
 static ev_signal_callback ev_signal_on_sigint;
 #endif
 
-#if WANT_SIGINT_HANDLING
+#ifdef WANT_SIGNAL_HANDLING
 typedef void ev_timer_callback(struct ev_loop*, ev_timer*, const int);
 static ev_timer_callback ev_timer_ontick;
 ev_timer timeout_watcher;
@@ -88,7 +88,7 @@ void server_run(ServerInfo* server_info)
   ev_io_init(&thread_info.accept_watcher, ev_io_on_request, server_info->sockfd, EV_READ);
   ev_io_start(mainloop, &thread_info.accept_watcher);
 
-#if WANT_SIGINT_HANDLING
+#ifdef WANT_SIGINT_HANDLING
   ev_signal sigint_watcher;
   ev_signal_init(&sigint_watcher, ev_signal_on_sigint, SIGINT);
   ev_signal_start(mainloop, &sigint_watcher);
@@ -107,7 +107,7 @@ void server_run(ServerInfo* server_info)
   Py_END_ALLOW_THREADS
 }
 
-#if WANT_SIGINT_HANDLING
+#ifdef WANT_SIGINT_HANDLING
 static void
 pyerr_set_interrupt(struct ev_loop* mainloop, struct ev_cleanup* watcher, const int events)
 {
@@ -132,7 +132,7 @@ ev_signal_on_sigint(struct ev_loop* mainloop, ev_signal* watcher, const int even
 }
 #endif
 
-#if WANT_SIGNAL_HANDLING
+#ifdef WANT_SIGNAL_HANDLING
 static void
 ev_timer_ontick(struct ev_loop* mainloop, ev_timer* watcher, const int events)
 {

--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -20,9 +20,13 @@
 
 #ifdef WANT_STATSD
 # include "statsd-client.h"
-# define SERVER_RUN_ARGS ServerInfo* server_info, statsd_link* statsd
+  #ifdef WANT_STATSD_TAGS
+    #define SERVER_RUN_ARGS ServerInfo* server_info, statsd_link* statsd, const char* statsd_tags
+  #else
+    #define SERVER_RUN_ARGS ServerInfo* server_info, statsd_link* statsd
+  #endif
 #else
-# define SERVER_RUN_ARGS ServerInfo* server_info
+  #define SERVER_RUN_ARGS ServerInfo* server_info
 #endif
 
 #include "py2py3.h"
@@ -56,6 +60,9 @@ typedef struct {
   ev_io accept_watcher;
 #ifdef WANT_STATSD
   statsd_link* statsd;
+# ifdef WANT_STATSD_TAGS
+  char* statsd_tags
+# endif
 #endif
 } ThreadInfo;
 
@@ -92,6 +99,9 @@ void server_run(SERVER_RUN_ARGS)
 
 #ifdef WANT_STATSD
   thread_info.statsd = statsd;
+#ifdef WANT_STATSD_TAGS
+  thread_info.statsd_tags = statsd_tags;
+#endif
 #endif
 
   ev_set_userdata(mainloop, &thread_info);

--- a/bjoern/server.c
+++ b/bjoern/server.c
@@ -17,7 +17,13 @@
 #include "common.h"
 #include "wsgi.h"
 #include "server.h"
-#include "statsd-client.h"
+
+#ifdef WANT_STATSD
+# include "statsd-client.h"
+# define SERVER_RUN_ARGS ServerInfo* server_info, statsd_link* statsd
+#else
+# define SERVER_RUN_ARGS ServerInfo* server_info
+#endif
 
 #include "py2py3.h"
 
@@ -47,8 +53,10 @@ typedef enum _rw_state write_state;
 
 typedef struct {
   ServerInfo* server_info;
-  statsd_link* statsd;
   ev_io accept_watcher;
+#ifdef WANT_STATSD
+  statsd_link* statsd;
+#endif
 } ThreadInfo;
 
 typedef void ev_io_callback(struct ev_loop*, ev_io*, const int);
@@ -75,13 +83,17 @@ static bool handle_nonzero_errno(Request*);
 static void close_connection(struct ev_loop*, Request*);
 
 
-void server_run(ServerInfo* server_info, statsd_link* statsd)
+void server_run(SERVER_RUN_ARGS)
 {
   struct ev_loop* mainloop = ev_loop_new(0);
 
   ThreadInfo thread_info;
   thread_info.server_info = server_info;
+
+#ifdef WANT_STATSD
   thread_info.statsd = statsd;
+#endif
+
   ev_set_userdata(mainloop, &thread_info);
 
   ev_io_init(&thread_info.accept_watcher, ev_io_on_request, server_info->sockfd, EV_READ);
@@ -147,19 +159,18 @@ ev_io_on_request(struct ev_loop* mainloop, ev_io* watcher, const int events)
   int client_fd;
   struct sockaddr_in sockaddr;
   socklen_t addrlen;
-  statsd_link* statsd = ((ThreadInfo*) ev_userdata(mainloop))->statsd;
 
   addrlen = sizeof(struct sockaddr_in);
   client_fd = accept(watcher->fd, (struct sockaddr*)&sockaddr, &addrlen);
   if(client_fd < 0) {
     DBG("Could not accept() client: errno %d", errno);
-    statsd_inc(statsd, "conn.accept.error", 1.0);
+    STATSD_INC("conn.accept.error");
     return;
   }
 
   int flags = fcntl(client_fd, F_GETFL, 0);
   if(fcntl(client_fd, F_SETFL, (flags < 0 ? 0 : flags) | O_NONBLOCK) == -1) {
-    statsd_inc(statsd, "conn.accept.error", 1.0);
+    STATSD_INC("conn.accept.error");
     DBG("Could not set_nonblocking() client %d: errno %d", client_fd, errno);
     return;
   }
@@ -174,7 +185,7 @@ ev_io_on_request(struct ev_loop* mainloop, ev_io* watcher, const int events)
 
   GIL_UNLOCK(0);
 
-  statsd_inc(statsd, "conn.accept.success", 1.0);
+  STATSD_INC("conn.accept.success");
 
   DBG_REQ(request, "Accepted client %s:%d on fd %d",
           inet_ntoa(sockaddr.sin_addr), ntohs(sockaddr.sin_port), client_fd);
@@ -206,7 +217,6 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
 {
   static char read_buf[READ_BUFFER_SIZE];
 
-  statsd_link* statsd = ((ThreadInfo*) ev_userdata(mainloop))->statsd;
   Request* request = REQUEST_FROM_WATCHER(watcher);
   read_state read_state;
 
@@ -222,7 +232,7 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
     /* Client disconnected */
     read_state = aborted;
     DBG_REQ(request, "Client disconnected");
-    statsd_inc(statsd, "req.error.client_disconnected", 1.0);
+    STATSD_INC("req.error.client_disconnected");
   } else if (read_bytes < 0) {
     /* Would block or error */
     if(errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -230,7 +240,7 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
     } else {
       read_state = aborted;
       DBG_REQ(request, "Hit errno %d while read()ing", errno);
-      statsd_inc(statsd, "req.error.read", 1.0);
+      STATSD_INC("req.error.read");
     }
   } else {
     /* OK, either expect more data or done reading */
@@ -239,7 +249,7 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
       /* HTTP parse error */
       read_state = done;
       DBG_REQ(request, "Parse error");
-      statsd_inc(statsd, "req.error.parse", 1.0);
+      STATSD_INC("req.error.parse");
       request->current_chunk = _PEP3333_Bytes_FromString(
         http_error_messages[request->state.error_code]);
       assert(request->iterator == NULL);
@@ -248,7 +258,7 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
        * request (the header _and_ the body). */
       read_state = done;
 
-      statsd_inc(statsd, "req.success.read", 1.0);
+      STATSD_INC("req.success.read");
 
       if (!wsgi_call_application(request)) {
         /* Response is "HTTP 500 Internal Server Error" */
@@ -259,7 +269,7 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
         Py_XCLEAR(request->iterator);
         request->current_chunk = _PEP3333_Bytes_FromString(
           http_error_messages[HTTP_SERVER_ERROR]);
-        statsd_inc(statsd, "req.error.internal", 1.0);
+        STATSD_INC("req.error.internal");
       }
     } else if (request->state.expect_continue) {
       /*
@@ -276,7 +286,7 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
 
   switch (read_state) {
   case not_yet_done:
-    statsd_inc(statsd, "req.active", 1.0);
+    STATSD_INC("req.active");
     break;
   case expect_continue:
     DBG_REQ(request, "pause read, write 100-continue");
@@ -288,11 +298,11 @@ ev_io_on_read(struct ev_loop* mainloop, ev_io* watcher, const int events)
     DBG_REQ(request, "Stop read watcher, start write watcher");
     ev_io_stop(mainloop, &request->ev_watcher);
     start_writing(mainloop, request);
-    statsd_inc(statsd, "req.done", 1.0);
+    STATSD_INC("req.done");
     break;
   case aborted:
     close_connection(mainloop, request);
-    statsd_inc(statsd, "req.aborted", 1.0);
+    STATSD_INC("req.aborted");
     break;
   }
 
@@ -320,8 +330,6 @@ ev_io_on_write(struct ev_loop* mainloop, ev_io* watcher, const int events)
    */
   Request* request = REQUEST_FROM_WATCHER(watcher);
 
-  statsd_link* statsd = ((ThreadInfo*) ev_userdata(mainloop))->statsd;
-
   GIL_LOCK(0);
 
   write_state write_state;
@@ -337,13 +345,13 @@ ev_io_on_write(struct ev_loop* mainloop, ev_io* watcher, const int events)
 
   switch(write_state) {
   case not_yet_done:
-    statsd_inc(statsd, "resp.active", 1.0);
+    STATSD_INC("resp.active");
     break;
   case done:
-    statsd_inc(statsd, "resp.done", 1.0);
+    STATSD_INC("resp.done");
     if(request->state.keep_alive) {
       DBG_REQ(request, "done, keep-alive");
-      statsd_inc(statsd, "resp.done.keepalive", 1.0);
+      STATSD_INC("resp.done.keepalive");
       ev_io_stop(mainloop, &request->ev_watcher);
 
       Request_clean(request);
@@ -352,7 +360,7 @@ ev_io_on_write(struct ev_loop* mainloop, ev_io* watcher, const int events)
       start_reading(mainloop, request);
     } else {
       DBG_REQ(request, "done, close");
-      statsd_inc(statsd, "resp.conn.close", 1.0);
+      STATSD_INC("resp.conn.close");
       close_connection(mainloop, request);
     }
     break;
@@ -367,7 +375,7 @@ ev_io_on_write(struct ev_loop* mainloop, ev_io* watcher, const int events)
     /* Response was aborted due to an error. We can't do anything graceful here
      * because at least one chunk is already sent... just close the connection. */
     close_connection(mainloop, request);
-    statsd_inc(statsd, "resp.aborted", 1.0);
+    STATSD_INC("resp.aborted");
     break;
   }
 

--- a/bjoern/server.h
+++ b/bjoern/server.h
@@ -18,4 +18,6 @@ typedef struct {
 #endif
 } ServerInfo;
 
+void server_run(ServerInfo*);
+
 #endif

--- a/bjoern/server.h
+++ b/bjoern/server.h
@@ -1,6 +1,8 @@
 #ifndef __server_h__
 #define __server_h__
 
+#include "statsd-client.h"
+
 typedef struct {
   int sockfd;
   PyObject* wsgi_app;
@@ -8,6 +10,13 @@ typedef struct {
   PyObject* port;
 } ServerInfo;
 
-void server_run(ServerInfo*);
+typedef struct {
+  int enabled;
+  int port;
+  char* host;
+  char* namespace;
+} StatsdInfo;
+
+void server_run(ServerInfo*, statsd_link*);
 
 #endif

--- a/bjoern/server.h
+++ b/bjoern/server.h
@@ -1,14 +1,15 @@
 #ifndef __server_h__
 #define __server_h__
 
-#include "statsd-client.h"
-
 typedef struct {
   int sockfd;
   PyObject* wsgi_app;
   PyObject* host;
   PyObject* port;
 } ServerInfo;
+
+#ifdef WANT_STATSD
+#include "statsd-client.h"
 
 typedef struct {
   int enabled;
@@ -18,5 +19,9 @@ typedef struct {
 } StatsdInfo;
 
 void server_run(ServerInfo*, statsd_link*);
+
+#else
+void server_run(ServerInfo*);
+#endif
 
 #endif

--- a/bjoern/server.h
+++ b/bjoern/server.h
@@ -18,7 +18,11 @@ typedef struct {
   char* namespace;
 } StatsdInfo;
 
-void server_run(ServerInfo*, statsd_link*);
+  #ifdef WANT_STATSD_TAGS
+  void server_run(ServerInfo*, statsd_link*, const char*);
+  #else
+  void server_run(ServerInfo*, statsd_link*);
+  #endif
 
 #else
 void server_run(ServerInfo*);

--- a/bjoern/server.h
+++ b/bjoern/server.h
@@ -1,31 +1,21 @@
 #ifndef __server_h__
 #define __server_h__
 
+#ifdef WANT_STATSD
+#include "statsd-client.h"
+#endif
+
 typedef struct {
   int sockfd;
   PyObject* wsgi_app;
   PyObject* host;
   PyObject* port;
-} ServerInfo;
-
 #ifdef WANT_STATSD
-#include "statsd-client.h"
-
-typedef struct {
-  int enabled;
-  int port;
-  char* host;
-  char* namespace;
-} StatsdInfo;
-
-  #ifdef WANT_STATSD_TAGS
-  void server_run(ServerInfo*, statsd_link*, const char*);
-  #else
-  void server_run(ServerInfo*, statsd_link*);
-  #endif
-
-#else
-void server_run(ServerInfo*);
+  statsd_link* statsd;
+# ifdef WANT_STATSD_TAGS
+  char* statsd_tags;
+# endif
 #endif
+} ServerInfo;
 
 #endif

--- a/bjoern/statsd_tags.c
+++ b/bjoern/statsd_tags.c
@@ -3,24 +3,12 @@
 
 #define MAX_MSG_LEN_WITH_TAGS 1000
 
-/* will change the original string */
-static void cleanup(char *stat)
-{
-  char *p;
-  for (p = stat; *p; p++) {
-    if (*p == ':' || *p == '|' || *p == '@') {
-      *p = '_';
-    }
-  }
-}
-
 static int send_stats_with_tags(statsd_link* link, char *stat, size_t value, const char* type, const char* tags)
 {
   if(!link) return 0;
 
   char message[MAX_MSG_LEN_WITH_TAGS];
 
-  cleanup(stat);
   snprintf(message, MAX_MSG_LEN_WITH_TAGS, "%s%s:%zd|%s|#%s", link->ns ? link->ns : "", stat, value, type, tags ? tags : "");
 
   return statsd_send(link, message);

--- a/bjoern/statsd_tags.c
+++ b/bjoern/statsd_tags.c
@@ -5,12 +5,13 @@
 
 static int send_stats_with_tags(statsd_link* link, char *stat, size_t value, const char* type, const char* tags)
 {
-  if(!link) return 0;
+  if (link == NULL) {
+    // Statsd disabled
+    return 0;
+  }
 
   char message[MAX_MSG_LEN_WITH_TAGS];
-
   snprintf(message, MAX_MSG_LEN_WITH_TAGS, "%s%s:%zd|%s|#%s", link->ns ? link->ns : "", stat, value, type, tags ? tags : "");
-
   return statsd_send(link, message);
 }
 

--- a/bjoern/statsd_tags.c
+++ b/bjoern/statsd_tags.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include "statsd-client.h"
+
+#define MAX_MSG_LEN_WITH_TAGS 1000
+
+/* will change the original string */
+static void cleanup(char *stat)
+{
+  char *p;
+  for (p = stat; *p; p++) {
+    if (*p == ':' || *p == '|' || *p == '@') {
+      *p = '_';
+    }
+  }
+}
+
+static int send_stats_with_tags(statsd_link* link, char *stat, size_t value, const char* type, const char* tags)
+{
+  if(!link) return 0;
+
+  char message[MAX_MSG_LEN_WITH_TAGS];
+
+  cleanup(stat);
+  snprintf(message, MAX_MSG_LEN_WITH_TAGS, "%s%s:%zd|%s|#%s", link->ns ? link->ns : "", stat, value, type, tags ? tags : "");
+
+  return statsd_send(link, message);
+}
+
+int statsd_inc_with_tags(statsd_link* link, char* stat, const char* tags)
+{
+  return send_stats_with_tags(link, stat, 1, "c", tags);
+}

--- a/bjoern/statsd_tags.h
+++ b/bjoern/statsd_tags.h
@@ -1,0 +1,9 @@
+#ifndef __statsd_tags__
+#define __statsd_tags__
+
+#include "statsd-client.h"
+
+int send_stats_with_tags(statsd_link* link, char *stat, size_t value, const char *type, const char* tags);
+int statsd_inc_with_tags(statsd_link* link, char *stat, const char* tags);
+
+#endif

--- a/instrumentation.md
+++ b/instrumentation.md
@@ -24,6 +24,7 @@ bjoern.listen(wsgi_application, host, port)
 bjoern.run(statsd={'enable': True, 'host': '...', port: ..., ns: 'bjoern'})
 
 # With tags
+# Note that the tags parameter takes a comma separated string of tags, not a list of strings.
 bjoern.run(statsd={'enable': True, 'host': '...', port: ..., ns: 'bjoern', 'tags': 'app:my-app-name,zone:central-europe'})
 ```
 

--- a/instrumentation.md
+++ b/instrumentation.md
@@ -1,0 +1,24 @@
+## Instrumentation
+
+Bjoern can export connection and request metrics to statsd. You can enable statsd metrics on server boot by setting `enable_statsd=True`.
+
+Following metrics are exposed:
+
+| Name | Type | Description |
+|:------:|:------:|:-------------|
+| `conn.accept.error` | increment | Incremented if bjoern fails to accept the socket connection from client |
+| `conn.accept.success` | increment | Incremented when a socket connection is accepted successfully |
+| `req.error.client_disconnected` | increment | Incremented if client disconnects before bjoern could read request |
+| `req.error.read` | increment | Incremented if bjoern fails to read request data from a valid connection |
+| `req.error.parse` | increment | Incremented if bjoern fails to parse the content as valid HTTP request |
+| `req.success.read` | increment | Incremented every time a request is read and parsed successfully |
+| `req.error.internal` | increment | Incremented if bjoern fails to successfully call the WSGI application |
+| `req.active` | increment | Incremented when a request is accepted as a valid one and bjoern is expecting more data from client |
+| `req.done` | increment | Incremented when a request is read and parsed completely and no more data is expected from client, server is expected to send response now |
+| `req.aborted` | increment | Incremented if the request is aborted before it was read or parsed completely. At the moment this is same as `req.error.read` but logically these are two different things and will diverge in future |
+| `resp.active` | increment | Incremented when bjoern is sending response and |
+| `resp.done` | increment | Incremented when bjoern is done sending the response |
+| `resp.done.keepalive` | increment | Incremented when the response is sent but the connection is kept alive |
+| `resp.conn.close` | increment | Incremented when the response is sent and connection is closed |
+| `resp.aborted` | increment | Incremented when there is an error in sending response. At this point the connection is also closed |
+

--- a/instrumentation.md
+++ b/instrumentation.md
@@ -1,6 +1,27 @@
 ## Instrumentation
 
-Bjoern can export connection and request metrics to statsd. You can enable statsd metrics on server boot by setting `enable_statsd=True`.
+Bjoern can export connection and request metrics to statsd. If you want support for instrumentation you must compile
+bjoern manually with
+
+```bash
+WANT_STATSD=yes make all
+```
+
+you can also enable Dogstatsd tags support by compiling with
+
+```bash
+WANT_STATSD=yes WANT_STATSD_TAGS=yes make all
+```
+
+After building with statsd support you can enable statsd metrics on server boot by setting `enable_statsd=True`, e.g.
+
+```python
+bjoern.listen(wsgi_application, host, port)
+bjoern.run(enable_statsd=True)
+
+# With tags
+bjoern.run(enable_statsd=True, statsd_tags=['app:my-app-name', 'zone:central-europe'])
+```
 
 Following metrics are exposed:
 

--- a/instrumentation.md
+++ b/instrumentation.md
@@ -4,12 +4,16 @@ Bjoern can export connection and request metrics to statsd. If you want support 
 bjoern manually with
 
 ```bash
+BJOERN_WANT_STATSD=yes python setup.py install
+# or
 WANT_STATSD=yes make all
 ```
 
 you can also enable Dogstatsd tags support by compiling with
 
 ```bash
+BJOERN_WANT_STATSD=yes BJOERN_WANT_STATSD_TAGS=yes python setup.py install
+# or
 WANT_STATSD=yes WANT_STATSD_TAGS=yes make all
 ```
 
@@ -17,10 +21,10 @@ After building with statsd support you can enable statsd metrics on server boot 
 
 ```python
 bjoern.listen(wsgi_application, host, port)
-bjoern.run(enable_statsd=True)
+bjoern.run(statsd={'enable': True, 'host': '...', port: ..., ns: 'bjoern'})
 
 # With tags
-bjoern.run(enable_statsd=True, statsd_tags=['app:my-app-name', 'zone:central-europe'])
+bjoern.run(statsd={'enable': True, 'host': '...', port: ..., ns: 'bjoern', 'tags': 'app:my-app-name,zone:central-europe'})
 ```
 
 Following metrics are exposed:

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ bjoern_extension = Extension(
                      ('WANT_SIGINT_HANDLING', '1'),
                      ('WANT_SIGNAL_HANDLING', '1'),
                      ('WANT_STATSD', '1'),
+                     ('WANT_STATSD_TAGS', '1'),
                      ('SIGNAL_CHECK_INTERVAL', '0.1')],
     extra_compile_args = ['-std=c99', '-fno-strict-aliasing', '-fcommon',
                           '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,15 @@ import os
 import glob
 from setuptools import setup, Extension
 
-SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c')] + \
+SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c'),
+                os.path.join('statsd-c-client', 'statsd-client.c')] + \
                sorted(glob.glob(os.path.join('bjoern', '*.c')))
 
 bjoern_extension = Extension(
     '_bjoern',
     sources       = SOURCE_FILES,
     libraries     = ['ev'],
-    include_dirs  = ['http-parser', '/usr/include/libev', '/opt/local/include'],
+    include_dirs  = ['http-parser', 'statsd-c-client', '/usr/include/libev', '/opt/local/include'],
     define_macros = [('WANT_SENDFILE', '1'),
                      ('WANT_SIGINT_HANDLING', '1'),
                      ('WANT_SIGNAL_HANDLING', '1'),

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,17 @@ import os
 import glob
 from setuptools import setup, Extension
 
-SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c'),
-                os.path.join('statsd-c-client', 'statsd-client.c')] + \
+SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c')] + \
                sorted(glob.glob(os.path.join('bjoern', '*.c')))
 
 bjoern_extension = Extension(
     '_bjoern',
     sources       = SOURCE_FILES,
     libraries     = ['ev'],
-    include_dirs  = ['http-parser', 'statsd-c-client', '/usr/include/libev', '/opt/local/include'],
+    include_dirs  = ['http-parser', '/usr/include/libev', '/opt/local/include'],
     define_macros = [('WANT_SENDFILE', '1'),
                      ('WANT_SIGINT_HANDLING', '1'),
                      ('WANT_SIGNAL_HANDLING', '1'),
-                     ('WANT_STATSD', '1'),
-                     ('WANT_STATSD_TAGS', '1'),
                      ('SIGNAL_CHECK_INTERVAL', '0.1')],
     extra_compile_args = ['-std=c99', '-fno-strict-aliasing', '-fcommon',
                           '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ bjoern_extension = Extension(
     define_macros = [('WANT_SENDFILE', '1'),
                      ('WANT_SIGINT_HANDLING', '1'),
                      ('WANT_SIGNAL_HANDLING', '1'),
+                     ('WANT_STATSD', '1'),
                      ('SIGNAL_CHECK_INTERVAL', '0.1')],
     extra_compile_args = ['-std=c99', '-fno-strict-aliasing', '-fcommon',
                           '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',

--- a/tests/features.py
+++ b/tests/features.py
@@ -1,0 +1,6 @@
+import bjoern
+
+if __name__ == '__main__':
+    for k, v in bjoern.features.iteritems():
+        print('{}: {}'.format(k, v))
+

--- a/tests/hello.py
+++ b/tests/hello.py
@@ -29,4 +29,4 @@ def wsgi_app(env, start_response):
     return choice(apps)(env, start_response)
 
 if __name__ == '__main__':
-    bjoern.run(wsgi_app, '0.0.0.0', 8080)
+    bjoern.run(wsgi_app, '127.0.0.1', 8080)

--- a/tests/hello_statsd.py
+++ b/tests/hello_statsd.py
@@ -29,4 +29,4 @@ def wsgi_app(env, start_response):
     return choice(apps)(env, start_response)
 
 if __name__ == '__main__':
-    bjoern.run(wsgi_app, '0.0.0.0', 8080, statsd={'enable': True})
+    bjoern.run(wsgi_app, '127.0.0.1', 8080, statsd={'enable': True, 'host': '127.0.0.1', 'port': 8888, 'ns': 'bjoern'})

--- a/tests/hello_statsd.py
+++ b/tests/hello_statsd.py
@@ -1,0 +1,32 @@
+import bjoern
+from random import choice
+
+def app1(env, sr):
+    #print(env)
+    sr('200 ok', [('Foo', 'Bar'), ('Blah', 'Blubb'), ('Spam', 'Eggs'), ('Blurg', 'asdasjdaskdasdjj asdk jaks / /a jaksdjkas jkasd jkasdj '),
+                  ('asd2easdasdjaksdjdkskjkasdjka', 'oasdjkadk kasdk k k k k k ')])
+    return [b'hello', b'world']
+
+def app2(env, sr):
+    #print(env)
+    sr('200 ok', [])
+    return b'hello'
+
+def app3(env, sr):
+    #print(env)
+    sr('200 abc', [('Content-Length', '12')])
+    yield b'Hello'
+    yield b' World'
+    yield b'\n'
+
+def app4(e, sr):
+    sr('200 ok', [])
+    return [b'hello there ... \n']
+
+apps = (app1, app2, app3, app4)
+
+def wsgi_app(env, start_response):
+    return choice(apps)(env, start_response)
+
+if __name__ == '__main__':
+    bjoern.run(wsgi_app, '0.0.0.0', 8080, enable_statsd=True)

--- a/tests/hello_statsd.py
+++ b/tests/hello_statsd.py
@@ -29,4 +29,4 @@ def wsgi_app(env, start_response):
     return choice(apps)(env, start_response)
 
 if __name__ == '__main__':
-    bjoern.run(wsgi_app, '0.0.0.0', 8080, enable_statsd=True)
+    bjoern.run(wsgi_app, '0.0.0.0', 8080, statsd={'enable': True})

--- a/tests/hello_statsd_with_tags.py
+++ b/tests/hello_statsd_with_tags.py
@@ -29,4 +29,4 @@ def wsgi_app(env, start_response):
     return choice(apps)(env, start_response)
 
 if __name__ == '__main__':
-    bjoern.run(wsgi_app, '0.0.0.0', 8080, statsd={'enable': True, 'tags': ['tag1:val1', 'tag2:val2']})
+    bjoern.run(wsgi_app, '0.0.0.0', 8080, statsd={'enable': True, 'host': '127.0.0.1', 'port': 8888, 'ns': 'bjoern', 'tags': 'tag1:val1,tag2:val2'})

--- a/tests/hello_statsd_with_tags.py
+++ b/tests/hello_statsd_with_tags.py
@@ -1,0 +1,32 @@
+import bjoern
+from random import choice
+
+def app1(env, sr):
+    #print(env)
+    sr('200 ok', [('Foo', 'Bar'), ('Blah', 'Blubb'), ('Spam', 'Eggs'), ('Blurg', 'asdasjdaskdasdjj asdk jaks / /a jaksdjkas jkasd jkasdj '),
+                  ('asd2easdasdjaksdjdkskjkasdjka', 'oasdjkadk kasdk k k k k k ')])
+    return [b'hello', b'world']
+
+def app2(env, sr):
+    #print(env)
+    sr('200 ok', [])
+    return b'hello'
+
+def app3(env, sr):
+    #print(env)
+    sr('200 abc', [('Content-Length', '12')])
+    yield b'Hello'
+    yield b' World'
+    yield b'\n'
+
+def app4(e, sr):
+    sr('200 ok', [])
+    return [b'hello there ... \n']
+
+apps = (app1, app2, app3, app4)
+
+def wsgi_app(env, start_response):
+    return choice(apps)(env, start_response)
+
+if __name__ == '__main__':
+    bjoern.run(wsgi_app, '0.0.0.0', 8080, enable_statsd=True, statsd_tags=['tag1:val1', 'tag2:val2'])

--- a/tests/hello_statsd_with_tags.py
+++ b/tests/hello_statsd_with_tags.py
@@ -29,4 +29,4 @@ def wsgi_app(env, start_response):
     return choice(apps)(env, start_response)
 
 if __name__ == '__main__':
-    bjoern.run(wsgi_app, '0.0.0.0', 8080, enable_statsd=True, statsd_tags=['tag1:val1', 'tag2:val2'])
+    bjoern.run(wsgi_app, '0.0.0.0', 8080, statsd={'enable': True, 'tags': ['tag1:val1', 'tag2:val2']})


### PR DESCRIPTION
I've added metrics wherever they made sense to me, these are all simple `increment` metrics counting the number of times an event happened.

There is scope for `gauge` and `timer` too but I'm not sure those will be as helpful inside bjoern, almost all of these can also be exposed from the WSGI app.

I don't write C a lot so please feel free to suggest code design changes.

closes #167