### PR TITLE
Fixed client accepting flow

### DIFF
--- a/tests/client_for_server_with_workers.py
+++ b/tests/client_for_server_with_workers.py
@@ -1,0 +1,48 @@
+import logging
+import requests
+import time
+import timeit
+import sys
+import signal
+
+sleep_time = 2
+port = int(sys.argv[1]) if len(sys.argv) == 2 else 8081
+host = f"http://localhost:{port}/"
+
+print(f"Making requests on {host}")
+
+s = requests.Session()
+number_of_calls = 10
+server_pids = {}
+
+def shutdown(sig, frame):
+    logging.warning(f"Requests {server_pids}")
+    sys.exit()
+
+signal.signal(signal.SIGINT, shutdown)
+
+request_no = 0
+error_request_no = 0
+max_duration = 0
+min_duration = 9999
+errors = {}
+
+def http_call():
+    global request_no
+    global error_request_no
+    r = s.get(host)
+    server_pids[r.text] = server_pids.get(r.text, 0) + 1
+    if r.status_code != 200:
+        error_request_no += 1
+        raise Exception(r)
+    else:
+        request_no += 1
+
+while True:
+    t = timeit.timeit(http_call, number=number_of_calls)
+
+    max_duration = max(max_duration, t/number_of_calls)
+    min_duration = min(min_duration, t/number_of_calls)
+    sys.stdout.write("\r{0}".format(
+        f"r: {request_no:10}, er: {error_request_no:5}, min: {min_duration:2.6}s, max: {max_duration:2.6}s, pids {server_pids}"))
+    sys.stdout.flush()

--- a/tests/server_with_workers.py
+++ b/tests/server_with_workers.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python 
+
+import os
+import signal
+import sys
+import time
+import bjoern
+
+host = "0.0.0.0"
+port = int(sys.argv[1]) if len(sys.argv) == 2 else 8081
+workers = 3
+
+worker_pids = []
+
+socket = bjoern.bind_and_listen(host=host, port=port, listen_backlog=1)
+
+requests_count = 0
+
+print(f"http://{host}:{port} with {workers} workers")
+
+parent_pid = os.getpid()
+
+def shutdown(sig, frame):
+    print("Wait for children to exit")
+    for child_pid in worker_pids:
+        print(f"killing child with pid {child_pid}.")
+        os.kill(child_pid, signal.SIGINT)    
+
+def application(environ, start_response):
+    global requests_count
+    requests_count += 1
+    status = '200 OK'
+    output = bytes(str(os.getpid()), "utf-8")
+    response_headers = [('Content-type', 'text/plain'),
+                        ('Content-Length', str(len(output)))]
+    start_response(status, response_headers)
+    return [output]
+
+for i in range(workers):
+    pid = os.fork()
+
+    if pid > 0:
+        worker_pids.append(pid)
+    elif pid == 0:
+        worker_pids = []
+        # Run HTTP server
+        print(f"Start listening for {os.getpid()}")
+        try:
+           bjoern.server_run(socket, application)
+        except KeyboardInterrupt as _:
+            print(f"{os.getpid()}: {requests_count}")
+        sys.exit()
+
+if parent_pid == os.getpid():
+    signal.signal(signal.SIGINT, shutdown)
+
+while len(worker_pids) > 0:
+    child_pid, exit_status = os.wait()
+    if child_pid in worker_pids:
+        worker_pids.remove(child_pid)
+    else:
+        print(f"Child with pid {child_pid} not found in parent's process hash.")
+    print(f"Child with pid {child_pid} exited")
+
+sys.exit()


### PR DESCRIPTION
I am currently working on a platform that uses the microservice architecture and I am testing the use of bjoern as http server for our microservices. Our microservices are behind envoy proxy and under high stress I get timeouts for about 5% of the connections.

It seems to be a bjoern issue with the "keep-alive" flow.

**Current behavior in bjoern:**

- From time to time, after a request is served on a keep-alive connection, the new request triggers the `accept_watcher/ev_io_on_request` which puts bjoern in "accept mode", therefore the previous connection is terminated.

**Implemented behavior:**

-  After a new client is accepted, the `accept_watcher` is disabled. The watcher is enabled again only on the `close_connection` use case.

This has been tested with the version 3.0.1.