### PR TITLE
filewrapper close stream before deallocate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 3.1.0 TBA
     - #164 Add support for statsd metrics/events (Mohammad Gufran)
-    - Fix WSGI filewrapper support, close file before deallocate (Mauro Amico)
+    - #171 Fix WSGI filewrapper support, close file before deallocate (Mauro Amico)
 
 3.0.1 (June 6, 2019)
     - Fix #158, #160: Correct string type for WSGI environ

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 3.1.0 TBA
     - #164 Add support for statsd metrics/events (Mohammad Gufran)
+    - Fix WSGI filewrapper support, close file before deallocate (Mauro Amico)
 
 3.0.1 (June 6, 2019)
     - Fix #158, #160: Correct string type for WSGI environ

--- a/bjoern/filewrapper.c
+++ b/bjoern/filewrapper.c
@@ -11,6 +11,9 @@ int FileWrapper_GetFd(PyObject *self)
 void FileWrapper_Done(PyObject *self)
 {
   if (FW_self->fd != -1) {
+    if (PyObject_HasAttrString(FW_self->file, "close")) {
+      PyObject_CallMethod(FW_self->file, "close", NULL);
+    }
     PyFile_DecUseCount((PyFileObject*)FW_self->file);
   }
 }


### PR DESCRIPTION
Call, when available, close method at the end of streaming before deallocate file-like object.

In trueness, PEP-3333 ask that wrapper implements a close() method, but IMHO close during 
`FileWrapper_Done` could be, in bjoern, equivalent.

https://www.python.org/dev/peps/pep-3333/#optional-platform-specific-file-handling
> .. the iterable returned by wsgi.file_wrapper must have a close() method that invokes the original file-like object's close() method