### PR TITLE
Fix segmentation fault in old interpreters

### DIFF
--- a/bjoern/py2py3.h
+++ b/bjoern/py2py3.h
@@ -15,6 +15,7 @@
 #define _PEP3333_BytesLatin1_FromUnicode(u) PyUnicode_AsLatin1String(u)
 #define _PEP3333_String_FromUTF8String(data) PyUnicode_FromString(data)
 #define _PEP3333_String_FromLatin1StringAndSize(data, len) PyUnicode_DecodeLatin1(data, len, "replace")
+#define _PEP3333_String_Empty() PyUnicode_FromString("")
 #define _PEP3333_String_FromFormat(...) PyUnicode_FromFormat(__VA_ARGS__)
 #define _PEP3333_String_GET_SIZE(u) PyUnicode_GET_LENGTH(u)
 #define _PEP3333_String_Concat(u1, u2) PyUnicode_Concat(u1, u2)
@@ -31,6 +32,7 @@
 #define _PEP3333_Bytes_Resize(bytes, len) _PyString_Resize(bytes, len)
 #define _PEP3333_BytesLatin1_FromUnicode(u) (Py_INCREF(u),u)
 #define _PEP3333_String_FromUTF8String(data) PyString_FromString(data) // Assume UTF8
+#define _PEP3333_String_Empty() PyString_FromStringAndSize(NULL, 0)
 #define _PEP3333_String_FromFormat(...) PyString_FromFormat(__VA_ARGS__)
 #define _PEP3333_String_GET_SIZE(u) PyString_GET_SIZE(u)
 

--- a/bjoern/py2py3.h
+++ b/bjoern/py2py3.h
@@ -15,6 +15,10 @@
 #define _PEP3333_BytesLatin1_FromUnicode(u) PyUnicode_AsLatin1String(u)
 #define _PEP3333_String_FromUTF8String(data) PyUnicode_FromString(data)
 #define _PEP3333_String_FromLatin1StringAndSize(data, len) PyUnicode_DecodeLatin1(data, len, "replace")
+// Shouldn't use FromFormat here because of Python bug:
+// https://bugs.python.org/issue33817
+// While problem with PyUnicode_FromString("") was not reported, it's still better
+// to create empty string without formatting
 #define _PEP3333_String_Empty() PyUnicode_FromString("")
 #define _PEP3333_String_FromFormat(...) PyUnicode_FromFormat(__VA_ARGS__)
 #define _PEP3333_String_GET_SIZE(u) PyUnicode_GET_LENGTH(u)
@@ -32,6 +36,9 @@
 #define _PEP3333_Bytes_Resize(bytes, len) _PyString_Resize(bytes, len)
 #define _PEP3333_BytesLatin1_FromUnicode(u) (Py_INCREF(u),u)
 #define _PEP3333_String_FromUTF8String(data) PyString_FromString(data) // Assume UTF8
+// Can't use FromFormat here because of Python bug:
+// https://bugs.python.org/issue33817
+// Arguments (NULL, 0) will create empty string, it's explicitly allowed
 #define _PEP3333_String_Empty() PyString_FromStringAndSize(NULL, 0)
 #define _PEP3333_String_FromFormat(...) PyString_FromFormat(__VA_ARGS__)
 #define _PEP3333_String_GET_SIZE(u) PyString_GET_SIZE(u)

--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -398,14 +398,14 @@ void _initialize_request_module(ServerInfo* server_info)
       PyDict_SetItemString(wsgi_base_dict, "SERVER_NAME", server_info->host);
 
       if (server_info->port == Py_None) {
-      PyDict_SetItemString(wsgi_base_dict, "SERVER_PORT", _PEP3333_String_FromFormat(""));
+      PyDict_SetItemString(wsgi_base_dict, "SERVER_PORT", _PEP3333_String_Empty());
       } else {
         PyDict_SetItemString(wsgi_base_dict, "SERVER_PORT", _PEP3333_String_FromFormat("%i", server_info->port));
       }
      } else {
       /* SERVER_NAME is required, but not usefull with UNIX type sockets */
-      PyDict_SetItemString(wsgi_base_dict, "SERVER_NAME", _PEP3333_String_FromFormat(""));
-      PyDict_SetItemString(wsgi_base_dict, "SERVER_PORT", _PEP3333_String_FromFormat(""));
+      PyDict_SetItemString(wsgi_base_dict, "SERVER_NAME", _PEP3333_String_Empty());
+      PyDict_SetItemString(wsgi_base_dict, "SERVER_PORT", _PEP3333_String_Empty());
     }
   }
 }


### PR DESCRIPTION
Due to bug with constructing empty strings via PyString_FromFormat(),
bjoern crashed Python interpreter. It happens on Python 2 interpreters
before 2.7.16 and Python 3 interpreters before 3.5.
https://bugs.python.org/issue33817