### PR TITLE
Small step toward wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,12 @@ memwatch:
 	   echo; echo; \
 	   tail -n +25 /proc/$$(pgrep -n ${PYTHON})/smaps'
 
-upload:
-	${PYTHON} setup.py sdist upload
+packages:
+	${PYTHON} setup.py sdist
+	$(MAKE) -C packaging all
+
+upload: packages
+	twine upload dist/*.tar.gz dist/*.whl
 
 $(HTTP_PARSER_OBJ):
 	$(MAKE) -C $(HTTP_PARSER_DIR) http_parser.o CFLAGS_DEBUG_EXTRA=-fPIC CFLAGS_FAST_EXTRA=-fPIC

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ prepare-build:
 clean:
 	@rm -rf $(BUILD_DIR)/*
 
+distclean:
+	@rm -rf dist/
+
 AB		= ab -c 100 -n 10000
 TEST_URL	= "http://127.0.0.1:8080/a/b/c?k=v&k2=v2"
 

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -1,0 +1,1 @@
+pip-cache/

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,0 +1,4 @@
+all: manylinux2014 manylinux2010 manylinux1
+
+manylinux%:
+	IMAGE=quay.io/pypa/$@_x86_64 docker-compose run --rm builder

--- a/packaging/build_all.sh
+++ b/packaging/build_all.sh
@@ -14,8 +14,10 @@ distdir="${top_srcdir}/dist"
 teardown() {
 	# Get outer user ID and GID from self.
 	uid_gid="$(stat -c %u:%g "$0")"
-	# Ensure dist/ files are owned by user.
-	chown -R "$uid_gid" "$distdir"
+	if [ "${uid_gid}" != "0:0" ] ; then
+		# Ensure dist/ files are owned by user.
+		chown -R "$uid_gid" "$distdir"
+	fi
 }
 trap teardown INT EXIT TERM
 

--- a/packaging/build_all.sh
+++ b/packaging/build_all.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -eux
+#
+# Build wheels for all python interpreter installed in /opt/python as in
+# manylinux containers.
+#
+# By default, search for a sdist tarball for version described in setup.py.
+# Accepts a specific tarball as first argument.
+#
+
+top_srcdir="$(readlink -m "$0/../..")"
+distdir="${top_srcdir}/dist"
+
+# Ensure to always clean up, even on error.
+teardown() {
+	# Get outer user ID and GID from self.
+	uid_gid="$(stat -c %u:%g "$0")"
+	# Ensure dist/ files are owned by user.
+	chown -R "$uid_gid" "$distdir"
+}
+trap teardown INT EXIT TERM
+
+cd "$top_srcdir"
+
+export PIP_DISABLE_PIP_VERSION_CHECK=off
+export PIP_NO_PYTHON_VERSION_WARNING=on
+
+runtimes=(/opt/python/cp*)
+
+version="$("${runtimes[0]}/bin/python" setup.py --version)"
+tarname="bjoern-$version"
+sdist="${1-$distdir/$tarname.tar.gz}"
+
+if ! [ -f "$sdist" ] ; then
+	echo "Missing source tarball $sdist." >&2
+	exit 1
+fi
+
+yum install -q -y libev-devel
+if ! rpm --query --queryformat= libev-devel  ; then
+	# Looks like libev-devel is not available, like in manylinux1. Let's
+	# install from sources.
+	LIBEV_VERSION=4.33
+	curl http://dist.schmorp.de/libev/Attic/libev-${LIBEV_VERSION}.tar.gz --silent --output /tmp/libev-${LIBEV_VERSION}.tar.gz
+	tar xf /tmp/libev-${LIBEV_VERSION}.tar.gz -C /tmp/
+	(cd /tmp/libev-${LIBEV_VERSION}; ./configure)
+	make -C /tmp/libev-${LIBEV_VERSION}/
+	make -C /tmp/libev-${LIBEV_VERSION}/ install
+fi
+
+# Blacklist cp27-cp27m as it triggers: site-packages/_bjoern.so: undefined
+# symbol: PyUnicodeUCS2_AsLatin1String
+runtime_blacklist=(cp27-cp27m)
+for runtimedir in "${runtimes[@]}" ; do
+	if [[ " ${runtime_blacklist[*]]} " =~ " ${runtimedir##*/} " ]] ; then
+		continue
+	fi
+	PATH="$runtimedir/bin:$PATH" $top_srcdir/packaging/build_wheel.sh "$sdist"
+done

--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -eux
+#
+# This script accepts a source tarball as argument and product final wheel for
+# current python interpreter. The script saves the wheel in source tarball
+# directory and pen test it to validate build.
+#
+
+sdist="$1"
+basename=${sdist/%.tar.gz}
+wheeldir=${sdist%/*}
+
+srcdir=$(readlink -m "$0/..")
+wheeltag="$(python "$srcdir/wheeltag.py")"
+impl="${wheeltag% *}"
+default_platform="${wheeltag#* }"
+
+# Build wheel from source tarball
+pip --verbose wheel --no-deps --wheel-dir "$wheeldir" "$sdist"
+wheel="$basename-$impl-$default_platform.whl"
+
+# Fix wheel to embed libev shared object.
+auditwheel repair --wheel-dir "$wheeldir" "$wheel"
+rm -f "$wheel"
+wheel="$basename-$impl-$AUDITWHEEL_PLAT.whl"
+
+# Build a venv for pentesting
+venv=/tmp/bjoern-pentestenv
+rm -rf "$venv"
+if python -m venv --help &>/dev/null ; then
+  python -m venv "$venv"
+else
+  # For Python 2.7
+  pip install virtualenv
+  hash -r
+  virtualenv "$venv"
+fi
+"$venv/bin/pip" install --upgrade pip
+
+# Pentest wheel.
+$venv/bin/pip install "$wheel"
+cd /  # Move outside source tree.
+$venv/bin/python "$srcdir/../tests/test_wsgi_compliance.py"
+rm -rf $venv

--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  builder:
+    image: ${IMAGE-quay.io/pypa/manylinux2014_x86_64}
+    volumes:
+    - ..:/workspace
+    - ./pip-cache:/root/.cache/pip
+    working_dir: /workspace
+    command: [/workspace/packaging/build_all.sh]

--- a/packaging/wheeltag.py
+++ b/packaging/wheeltag.py
@@ -1,0 +1,16 @@
+# Exports interpreter PEP425 tags for shell processing.
+import sys
+from distutils.util import get_platform
+
+from wheel.pep425tags import (
+    get_impl_ver,
+    get_abi_tag,
+    get_abbr_impl,
+)
+
+sys.stdout.write("%s%s-%s %s\n" % (
+    get_abbr_impl(),
+    get_impl_ver(),
+    get_abi_tag(),
+    get_platform().replace('-', '_'),
+))


### PR DESCRIPTION
Hi @jonashaag ,

Here is a first step to build wheels as requested by #121. This PR is a small step : it does not change release process, does not change tests, does not add CI, does not support every binary platform.

To upload wheel, you need docker-compose and twine. Then, simply run `make upload`. There is two new Make targets : distclean (just cleaning dist dir) and `packages` to build without uploading.

``` console
$ make distclean packages
...
$ tree dist/
dist/
├── bjoern-3.1.0-cp27-cp27mu-manylinux1_x86_64.whl
├── bjoern-3.1.0-cp27-cp27mu-manylinux2010_x86_64.whl
├── bjoern-3.1.0-cp35-cp35m-manylinux1_x86_64.whl
├── bjoern-3.1.0-cp35-cp35m-manylinux2010_x86_64.whl
├── bjoern-3.1.0-cp35-cp35m-manylinux2014_x86_64.whl
├── bjoern-3.1.0-cp36-cp36m-manylinux1_x86_64.whl
├── bjoern-3.1.0-cp36-cp36m-manylinux2010_x86_64.whl
├── bjoern-3.1.0-cp36-cp36m-manylinux2014_x86_64.whl
├── bjoern-3.1.0-cp37-cp37m-manylinux1_x86_64.whl
├── bjoern-3.1.0-cp37-cp37m-manylinux2010_x86_64.whl
├── bjoern-3.1.0-cp37-cp37m-manylinux2014_x86_64.whl
├── bjoern-3.1.0-cp38-cp38-manylinux1_x86_64.whl
├── bjoern-3.1.0-cp38-cp38-manylinux2010_x86_64.whl
├── bjoern-3.1.0-cp38-cp38-manylinux2014_x86_64.whl
└── bjoern-3.1.0.tar.gz

0 directories, 15 files
$
```

libev **IS** embedded in wheel. I'm wondering if this will trigger issue like with psycopg2 and libpq. The workaround is to use source tarball rather than wheel.

Each wheel is pen tested in a virtualenv with `test_wsgi_compliance.py`.

I hit a bug with cp27m. Instead of fighting this, I choose to blacklist it for now. Users will still use sources.

The docker-compose.yml should be easy to translate to a CI job matrix, using either CircleCI, GitHub Action, Travis, Azure pipelines and/or appveyor.

@jonashaag what do you think of this ?

cc @hoefling