### PR TITLE
Ease contribution with .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{Makefile,*.sh}]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
Makefile requires tabs. Bash also handle tabs carefully (like `<<-` operator).

Many editor and IDE supports editorconfig file. Shipping a .editorconfig fixes the rules for this project, independently of user preference.