### PR TITLE
Fixes main problem in #181

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c')] + \
                sorted(glob.glob(os.path.join('bjoern', '*.c')))
 
 if not WANT_STATSD:
-    SOURCE_FILES.remove('/statsd-c-client/statsd-client.c')
-    SOURCE_FILES.remove('/bjoern/statsd_tags.c')
+    SOURCE_FILES.remove(os.path.join('statsd-c-client/statsd-client.c'))
+    SOURCE_FILES.remove(os.path.join('bjoern/statsd_tags.c'))
 
 bjoern_extension = Extension(
     '_bjoern',

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,9 @@ bjoern_extension = Extension(
     '_bjoern',
     sources       = SOURCE_FILES,
     libraries     = ['ev'],
-    include_dirs  = ['http-parser', 'statsd-c-client', '/usr/include/libev', '/opt/local/include')],
+    include_dirs  = ['http-parser', 'statsd-c-client', '/usr/include/libev', '/opt/local/include'],
     define_macros = compile_flags,
-    extra_compile_args = ['-std=c99', '-fno-strict-aliasing', '-fcommon',
-                          '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',
-                          '-Wno-missing-field-initializers', '-g']
+    extra_compile_args = COMPILE_ARGS
 )
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@ SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c')] + \
                [os.path.join('statsd-c-client', 'statsd-client.c')] + \
                sorted(glob.glob(os.path.join('bjoern', '*.c')))
 
-print(SOURCE_FILES)
-
 if not WANT_STATSD:
     SOURCE_FILES.remove(os.path.join('statsd-c-client', 'statsd-client.c'))
     SOURCE_FILES.remove(os.path.join('bjoern', 'statsd_tags.c'))

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c')] + \
 print(SOURCE_FILES)
 
 if not WANT_STATSD:
-    SOURCE_FILES.remove(os.path.join('statsd-c-client/statsd-client.c'))
-    SOURCE_FILES.remove(os.path.join('bjoern/statsd_tags.c'))
+    SOURCE_FILES.remove(os.path.join('statsd-c-client', 'statsd-client.c'))
+    SOURCE_FILES.remove(os.path.join('bjoern', 'statsd_tags.c'))
 
 bjoern_extension = Extension(
     '_bjoern',

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ if not WANT_STATSD:
 
 is_windows = True if os.name == "nt" else False
 
-DEFAULT_COMPILE_ARGS = ['-std=c99', '-fno-strict-aliasing', '-fcommon', '-fPIC', '-g']
-COMPILE_ARGS = DEFAULT_COMPILE_ARGS if is_windows else DEFAULT_COMPILE_ARGS + ['-Wall', '-Wextra', '-Wno-unused-parameter', '-Wno-missing-field-initializers']
+DEFAULT_COMPILE_ARGS = []
+COMPILE_ARGS = DEFAULT_COMPILE_ARGS if is_windows else DEFAULT_COMPILE_ARGS + [['-std=c99', '-fno-strict-aliasing', '-fcommon', '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter', '-Wno-missing-field-initializers', '-g']]
 
 bjoern_extension = Extension(
     '_bjoern',

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,16 @@ if not WANT_STATSD:
     SOURCE_FILES.remove(os.path.join('statsd-c-client', 'statsd-client.c'))
     SOURCE_FILES.remove(os.path.join('bjoern', 'statsd_tags.c'))
 
+is_windows = True if os.name == "nt" else False
+
+DEFAULT_COMPILE_ARGS = ['-std=c99', '-fno-strict-aliasing', '-fcommon', '-fPIC', '-Wno-unused-parameter', '-Wno-missing-field-initializers', '-g']
+COMPILE_ARGS = DEFAULT_COMPILE_ARGS if is_windows else DEFAULT_COMPILE_ARGS + ['-Wall', '-Wextra']
+
 bjoern_extension = Extension(
     '_bjoern',
     sources       = SOURCE_FILES,
     libraries     = ['ev'],
-    include_dirs  = ['http-parser', 'statsd-c-client', os.path.join('usr', 'include', 'libev'), os.path.join('opt', 'local', 'include')],
+    include_dirs  = ['http-parser', 'statsd-c-client', '/usr/include/libev', '/opt/local/include')],
     define_macros = compile_flags,
     extra_compile_args = ['-std=c99', '-fno-strict-aliasing', '-fcommon',
                           '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ if not WANT_STATSD:
 
 is_windows = True if os.name == "nt" else False
 
-DEFAULT_COMPILE_ARGS = ['-std=c99', '-fno-strict-aliasing', '-fcommon', '-fPIC', '-Wno-unused-parameter', '-Wno-missing-field-initializers', '-g']
-COMPILE_ARGS = DEFAULT_COMPILE_ARGS if is_windows else DEFAULT_COMPILE_ARGS + ['-Wall', '-Wextra']
+DEFAULT_COMPILE_ARGS = ['-std=c99', '-fno-strict-aliasing', '-fcommon', '-fPIC', '-g']
+COMPILE_ARGS = DEFAULT_COMPILE_ARGS if is_windows else DEFAULT_COMPILE_ARGS + ['-Wall', '-Wextra', '-Wno-unused-parameter', '-Wno-missing-field-initializers']
 
 bjoern_extension = Extension(
     '_bjoern',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ bjoern_extension = Extension(
     '_bjoern',
     sources       = SOURCE_FILES,
     libraries     = ['ev'],
-    include_dirs  = ['http-parser', 'statsd-c-client', '/usr/include/libev', '/opt/local/include'],
+    include_dirs  = ['http-parser', 'statsd-c-client', os.path.join('usr', 'include', 'libev'), os.path.join('opt', 'local', 'include')],
     define_macros = compile_flags,
     extra_compile_args = ['-std=c99', '-fno-strict-aliasing', '-fcommon',
                           '-fPIC', '-Wall', '-Wextra', '-Wno-unused-parameter',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c')] + \
                [os.path.join('statsd-c-client', 'statsd-client.c')] + \
                sorted(glob.glob(os.path.join('bjoern', '*.c')))
 
+print(SOURCE_FILES)
+
 if not WANT_STATSD:
     SOURCE_FILES.remove(os.path.join('statsd-c-client/statsd-client.c'))
     SOURCE_FILES.remove(os.path.join('bjoern/statsd_tags.c'))

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ SOURCE_FILES = [os.path.join('http-parser', 'http_parser.c')] + \
                sorted(glob.glob(os.path.join('bjoern', '*.c')))
 
 if not WANT_STATSD:
-    SOURCE_FILES.remove('statsd-c-client/statsd-client.c')
-    SOURCE_FILES.remove('bjoern/statsd_tags.c')
+    SOURCE_FILES.remove('/statsd-c-client/statsd-client.c')
+    SOURCE_FILES.remove('/bjoern/statsd_tags.c')
 
 bjoern_extension = Extension(
     '_bjoern',


### PR DESCRIPTION
Fixes download compatibility issue with Linux and windows.
Fixed download compile args problem

-- UNFIXED --
Error with building wheel:
```bash
ERROR: Command errored out with exit status 1:
   command: 'c:\users\gebruiker\appdata\local\programs\python\python38-32\python.exe' -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\Gebruiker\\AppData\\Local\\Temp\\pip-req-build-2xl9_d3h\\setup.py'"'"'; __f
ile__='"'"'C:\\Users\\Gebruiker\\AppData\\Local\\Temp\\pip-req-build-2xl9_d3h\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file
__, '"'"'exec'"'"'))' bdist_wheel -d 'C:\Users\Gebruiker\AppData\Local\Temp\pip-wheel-6np3qjqf'
       cwd: C:\Users\Gebruiker\AppData\Local\Temp\pip-req-build-2xl9_d3h\
  Complete output (23 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build\lib.win32-3.8
  copying bjoern.py -> build\lib.win32-3.8
  running build_ext
  building '_bjoern' extension
  creating build\temp.win32-3.8
  creating build\temp.win32-3.8\Release
  creating build\temp.win32-3.8\Release\http-parser
  creating build\temp.win32-3.8\Release\bjoern
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\bin\HostX86\x86\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DSIGNAL_CHECK_INTERVAL=0.1 -DWANT_SIGNAL_HANDLING=yes -DWANT_SIGINT_HANDLING=yes -
Ihttp-parser -Istatsd-c-client -I/usr/include/libev -I/opt/local/include -Ic:\users\gebruiker\appdata\local\programs\python\python38-32\include -Ic:\users\gebruiker\appdata\local\programs\python\python38-32\include "-IC:\Program Fil
es (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\ATLMFC\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include" "-IC:\Program Files (x86)\Windows Kits\NET
FXSDK\4.8\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um" "-I
C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\cppwinrt" /Tchttp-parser\http_parser.c /Fobuild\temp.win32-3.8\Release\http-parser\http_parser.obj
  http_parser.c
  http-parser\http_parser.c(1613): warning C4244: 'function': conversion from 'int64_t' to 'size_t', possible loss of data
  http-parser\http_parser.c(1627): warning C4244: 'function': conversion from 'int64_t' to 'size_t', possible loss of data
  http-parser\http_parser.c(1708): warning C4244: 'function': conversion from 'int64_t' to 'size_t', possible loss of data
  http-parser\http_parser.c(1748): warning C4244: '=': conversion from 'uint64_t' to 'unsigned char', possible loss of data
  http-parser\http_parser.c(1749): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\bin\HostX86\x86\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DSIGNAL_CHECK_INTERVAL=0.1 -DWANT_SIGNAL_HANDLING=yes -DWANT_SIGINT_HANDLING=yes -
Ihttp-parser -Istatsd-c-client -I/usr/include/libev -I/opt/local/include -Ic:\users\gebruiker\appdata\local\programs\python\python38-32\include -Ic:\users\gebruiker\appdata\local\programs\python\python38-32\include "-IC:\Program Fil
es (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\ATLMFC\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include" "-IC:\Program Files (x86)\Windows Kits\NET
FXSDK\4.8\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um" "-I
C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\cppwinrt" /Tcbjoern\_bjoernmodule.c /Fobuild\temp.win32-3.8\Release\bjoern\_bjoernmodule.obj
  _bjoernmodule.c
  C:\Users\Gebruiker\AppData\Local\Temp\pip-req-build-2xl9_d3h\bjoern\request.h(4): fatal error C1083: Cannot open include file: 'ev.h': No such file or directory
  error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.23.28105\\bin\\HostX86\\x86\\cl.exe' failed with exit status 2
  ----------------------------------------
  ERROR: Failed building wheel for bjoern

```