### PR TITLE
Ease wheel script teardown

### DIFF
--- a/packaging/build_all.sh
+++ b/packaging/build_all.sh
@@ -19,7 +19,7 @@ teardown() {
                 chown -R "$uid_gid" "$distdir"
         fi
 }
-trap teardown INT EXIT TERM
+trap 'set +x; teardown' INT EXIT TERM
 
 cd "$top_srcdir"
 

--- a/packaging/build_all.sh
+++ b/packaging/build_all.sh
@@ -12,12 +12,12 @@ distdir="${top_srcdir}/dist"
 
 # Ensure to always clean up, even on error.
 teardown() {
-	# Get outer user ID and GID from self.
-	uid_gid="$(stat -c %u:%g "$0")"
-	if [ "${uid_gid}" != "0:0" ] ; then
-		# Ensure dist/ files are owned by user.
-		chown -R "$uid_gid" "$distdir"
-	fi
+        # Get outer user ID and GID from self.
+        uid_gid="$(stat -c %u:%g "$0")"
+        if [ "${uid_gid}" != "0:0" ] && [ -d "$distdir" ]; then
+                # Ensure dist/ files are owned by user.
+                chown -R "$uid_gid" "$distdir"
+        fi
 }
 trap teardown INT EXIT TERM
 


### PR DESCRIPTION
Make error easier on the eyes:

Before :

```
+ tarname=bjoern-3.1.0                                
+ sdist=/workspace/dist/bjoern-3.1.0.tar.gz               
+ '[' -f /workspace/dist/bjoern-3.1.0.tar.gz ']'
+ echo 'Missing source tarball /workspace/dist/bjoern-3.1.0.tar.gz.'
Missing source tarball /workspace/dist/bjoern-3.1.0.tar.gz.
+ exit 1                                  
+ teardown                           
++ stat -c %u:%g /workspace/packaging/build_all.sh        
+ uid_gid=1000:1000                                      
+ '[' 1000:1000 '!=' 0:0 ']'                              
+ chown -R 1000:1000 /workspace/dist                    
chown: cannot access ‘/workspace/dist’: No such file or directory
ERROR: 1                             
make: *** [Makefile:4 : manylinux2014] Erreur 1       
```

After:

```
+ tarname=bjoern-3.1.0
+ sdist=/workspace/dist/bjoern-3.1.0.tar.gz
+ '[' -f /workspace/dist/bjoern-3.1.0.tar.gz ']'
+ echo 'Missing source tarball /workspace/dist/bjoern-3.1.0.tar.gz.'
Missing source tarball /workspace/dist/bjoern-3.1.0.tar.gz.
+ exit 1
+ set +x
ERROR: 1
make: *** [Makefile:4 : manylinux2014] Erreur 1
```