### PR TITLE
Set the wsgi.input_terminated flag in the WSGI environment for Flask.

### DIFF
--- a/bjoern/request.c
+++ b/bjoern/request.c
@@ -350,6 +350,16 @@ void _initialize_request_module(ServerInfo* server_info)
       PyTuple_Pack(2, _FromLong(1), _FromLong(0))
     );
 
+    /* dct['wsgi.input_terminated'] = True
+     * (Tell Flask/other WSGI apps that the input has been terminated, so that chunked
+     * transfer-encoding can be used in requests. This can be hard coded as bjoern
+     * provides the body as a BytesIO object.) */
+    PyDict_SetItemString(
+      wsgi_base_dict,
+      "wsgi.input_terminated",
+      Py_True
+    );
+
     /* dct['wsgi.url_scheme'] = 'http'
      * (This can be hard-coded as there is no TLS support in bjoern.) */
     Py_INCREF(_http);


### PR DESCRIPTION
I have a Flask server that expects to be able to receive `Transfer-Encoding: chunked` requests and process them. Flask/Werkzeug by default will prevent you from reading the payload of a HTTP request that doesn't have a `Content-Length` header, because it doesn't know if the stream may contain more requests - https://github.com/pallets/werkzeug/blob/560dd5f320bff318175f209595d42f5a80045417/src/werkzeug/wsgi.py#L141-L176. This user-visible result of this is that `flask.request.data` will be an empty byte string, and reading `flask.request.stream` will return nothing as well.

Armin Ronacher proposed an extension to WSGI that would allow WSGI servers to indicate when the payload is already terminated, and thus can be safely read - https://gist.github.com/mitsuhiko/5721547. This is done by setting `wsgi.input_terminated` in the WSGI environment. See https://github.com/pallets/werkzeug/blob/560dd5f320bff318175f209595d42f5a80045417/src/werkzeug/wsgi.py#L141-L176
for the relevant Werkzeug code.

This PR proposes that Bjoern can also support the `wsgi.input_terminated` flag, because it stores the payload into a BytesIO stream.

For some more context, https://github.com/benoitc/gunicorn/issues/1653 is the relevant discussion on the GUnicorn project where this extension was implemented. The code to reproduce this is quite simple:

Server:

```python
import bjoern
from flask import Flask, request


app = Flask("cool")


@app.route("/", methods=["POST"])
def index():
    print(request.data)
    return "ok"

if __name__ == "__main__":
    bjoern.run(app, "0.0.0.0", 5000, reuse_port=True)
    app.run(debug=True)
```

Client:

```python
import requests


def request_content():
    yield b"cool data"


def main():
    response = requests.post(
        "http://localhost:5000/",
        data=request_content(),
    )


if __name__ == "__main__":
    main()
```

Prior to this fix, the server would print `b''`. After the fix, it prints `b'cool data'` (i.e. the payload of the request).