### PR TITLE
Actualize CI + introduce publish job + build precompiled wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,159 @@
+name: Build and Publish to PyPI
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build_wheels:
+    name: Build wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            archs: x86_64 aarch64
+          - os: macos-15-intel
+            archs: x86_64
+          - os: macos-latest
+            archs: arm64
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Set up QEMU for Linux ARM64 emulation
+        if: matrix.os == 'ubuntu-latest'
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: aarch64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.1.0
+        env:
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
+          CIBW_SKIP: "*-musllinux* *-manylinux_i686"
+          # Install libev inside manylinux containers; fall back to building
+          # from source if libev-devel is not in the package repos (e.g. manylinux1).
+          CIBW_BEFORE_ALL_LINUX: >
+            yum install -y libev-devel ||
+            (LIBEV_VERSION=4.33 &&
+             curl -fsSL http://dist.schmorp.de/libev/Attic/libev-${LIBEV_VERSION}.tar.gz
+               -o /tmp/libev.tar.gz &&
+             tar xf /tmp/libev.tar.gz -C /tmp/ &&
+             cd /tmp/libev-${LIBEV_VERSION} && ./configure && make && make install)
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
+          CIBW_BEFORE_ALL_MACOS: >
+            LIBEV_VERSION=4.33 &&
+            curl -fsSL http://dist.schmorp.de/libev/Attic/libev-${LIBEV_VERSION}.tar.gz -o /tmp/libev.tar.gz &&
+            tar xf /tmp/libev.tar.gz -C /tmp/ &&
+            cd /tmp/libev-${LIBEV_VERSION} &&
+            MACOSX_DEPLOYMENT_TARGET=11.0 ./configure --prefix=/usr/local CFLAGS="-mmacosx-version-min=11.0" LDFLAGS="-mmacosx-version-min=11.0" &&
+            MACOSX_DEPLOYMENT_TARGET=11.0 make &&
+            sudo make install
+          # auditwheel (Linux) and delocate (macOS) are run automatically by
+          # cibuildwheel to bundle libev.so / libev.dylib into the wheel.
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.archs }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - run: pip install build
+      - run: python -m build --sdist
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bjoern
+    permissions:
+      id-token: write  # required for trusted publishing (OIDC)
+
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: [publish-to-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write  # required for sigstore signing
+
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+      - name: Sign with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          "$GITHUB_REF_NAME"
+          --repo "$GITHUB_REPOSITORY"
+          --notes ""
+
+      - name: Upload artifacts to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          "$GITHUB_REF_NAME" dist/**
+          --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,22 +7,23 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["2.7", "3.5", "3.10"]
+        os: [ubuntu-latest, macos-26-intel]
+        python-version: ["3.8", "3.10", "3.12", "3.14"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: sudo apt-get update && sudo apt-get install -y libev-dev
         if: matrix.os == 'ubuntu-latest'
       - run: brew install libev
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-26-intel'
       - name: Build
         run: |
-          python setup.py install
+          pip install setuptools
+          pip install .
           cd /tmp
           python -c "import bjoern"
         shell: bash -ex {0}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+setuptools; python_version >= "3.12"


### PR DESCRIPTION
See https://github.com/jonashaag/bjoern/issues/252 for motivation, implemented basic CI to publish not only sdist, but precompiled wheels with libev inside.

- unfortunately, support CI for py2.7 and 3.8 is not easy nowadays, so they are not implemented
- prebuilt for linux (x64, arm), macos (x64, arm), py3.9-3.14

You'll need to set `trusted publisher` in Pypi https://docs.pypi.org/trusted-publishers/adding-a-publisher/ to make it work after merge.

Actually, I took the liberty and tested publication on https://pypi.org/project/bjoern-binary/#files (with additional commit to change package name), here is the actual CI job https://github.com/gmelikov/bjoern/actions/runs/27778928896 , feel free to comment!

@jonashaag If you're not interested - won't you mind if I use https://pypi.org/project/bjoern-binary/ naming? I can remove/change website/etc in package info if you want, open to any suggestions. My target is to install bjoern fast and without additional `apt install`.

Before:
```
(test) root@ubuntu:/tmp/test# time uv pip install bjoern
Resolved 1 package in 3ms
      Built bjoern==3.2.2
Prepared 1 package in 1.63s
```

After:
```
(test) root@ubuntu:/tmp/test# time uv pip install bjoern-binary                                                                                                                                                                                                                                                                                                                                                                             
Resolved 1 package in 210ms
Prepared 1 package in 72ms
```

(`prepared` includes a time to compile), so up to 2 secs speedup and don't need to install libev-dev lib.

Benchmarked precompiled version on Linux x64 too, didn't see any difference from sdist version.

Closes #121 #252 